### PR TITLE
dcos_metrics output fixes

### DIFF
--- a/plugins/outputs/dcos_metrics/README.md
+++ b/plugins/outputs/dcos_metrics/README.md
@@ -21,4 +21,7 @@ The DC/OS Metrics output provides a [DC/OS Metrics API](https://docs.mesosphere.
 
   # Local Mesos instance's ID.
   mesos_id = "ABCDEF1234"
+
+  # Global DC/OS Cluster ID.
+  dcos_cluster_id = "4321FEDCBA"
 ```

--- a/plugins/outputs/dcos_metrics/dcos_metrics.go
+++ b/plugins/outputs/dcos_metrics/dcos_metrics.go
@@ -46,6 +46,9 @@ func (d *DCOSMetrics) SampleConfig() string {
 
   # Local Mesos instance's ID.
   mesos_id = "ABCDEF1234"
+
+  # Global DC/OS Cluster ID.
+  dcos_cluster_id = "4321FEDCBA"
 `
 }
 

--- a/plugins/outputs/dcos_metrics/translator.go
+++ b/plugins/outputs/dcos_metrics/translator.go
@@ -452,9 +452,10 @@ func (t *producerTranslator) systemMetricsMessage(m telegraf.Metric) producers.M
 	}
 }
 
-// datapointsFromMetric returns a []producers.Datapoint for the fields in m, with tags set on all Datapoints.
+// datapointsFromMetric returns a []producers.Datapoint for the fields in m.
+// Tags are applied to each Datapoint, and each Datapoint name is prefixed with namePrefix.
 // Datapoints are sorted by name for stability.
-func datapointsFromMetric(m telegraf.Metric, prefix string, tags map[string]string) []producers.Datapoint {
+func datapointsFromMetric(m telegraf.Metric, namePrefix string, tags map[string]string) []producers.Datapoint {
 	fields := m.Fields()
 	timestamp := timestampFromMetric(m)
 
@@ -472,9 +473,9 @@ func datapointsFromMetric(m telegraf.Metric, prefix string, tags map[string]stri
 		// If we have a single metric field whose name is value, omit it from the complete field name.
 		var name string
 		if len(fns) == 1 && fn == "value" {
-			name = prefix
+			name = namePrefix
 		} else {
-			name = prefix + "." + fn
+			name = namePrefix + "." + fn
 		}
 
 		datapoints[i] = producers.Datapoint{

--- a/plugins/outputs/dcos_metrics/translator.go
+++ b/plugins/outputs/dcos_metrics/translator.go
@@ -86,12 +86,14 @@ func (t *producerTranslator) containerMetricsMessage(m telegraf.Metric) producer
 	taskName := getAndDelete(tags, "task_name")
 	executorName := getAndDelete(tags, "executor_name")
 
+	dpTags := map[string]string{"container_id": containerID}
+	if executorName != "" {
+		dpTags["executor_name"] = executorName
+	}
+
 	return producers.MetricsMessage{
-		Name: producers.ContainerMetricPrefix,
-		Datapoints: datapointsFromMetric(m, producers.ContainerMetricPrefix, map[string]string{
-			"container_id":  containerID,
-			"executor_name": executorName,
-		}),
+		Name:       producers.ContainerMetricPrefix,
+		Datapoints: datapointsFromMetric(m, producers.ContainerMetricPrefix, dpTags),
 		Dimensions: producers.Dimensions{
 			MesosID:       t.MesosID,
 			ClusterID:     t.DCOSClusterID,

--- a/plugins/outputs/dcos_metrics/translator.go
+++ b/plugins/outputs/dcos_metrics/translator.go
@@ -88,7 +88,7 @@ func (t *producerTranslator) containerMetricsMessage(m telegraf.Metric) producer
 
 	return producers.MetricsMessage{
 		Name: producers.ContainerMetricPrefix,
-		Datapoints: datapointsFromMetric(m, map[string]string{
+		Datapoints: datapointsFromMetric(m, producers.ContainerMetricPrefix, map[string]string{
 			"container_id":  containerID,
 			"executor_name": executorName,
 		}),
@@ -114,9 +114,11 @@ func (t *producerTranslator) appMetricsMessage(m telegraf.Metric) producers.Metr
 	// We don't use metric_type.
 	delete(tags, "metric_type")
 
+	fieldNamePrefix := producers.AppMetricPrefix + "." + metricNameSuffix(m.Name())
+
 	return producers.MetricsMessage{
-		Name:       producers.AppMetricPrefix,
-		Datapoints: datapointsFromMetric(m, tags),
+		Name:       fieldNamePrefix,
+		Datapoints: datapointsFromMetric(m, fieldNamePrefix, tags),
 		Dimensions: producers.Dimensions{
 			MesosID:       t.MesosID,
 			ClusterID:     t.DCOSClusterID,
@@ -452,7 +454,7 @@ func (t *producerTranslator) systemMetricsMessage(m telegraf.Metric) producers.M
 
 // datapointsFromMetric returns a []producers.Datapoint for the fields in m, with tags set on all Datapoints.
 // Datapoints are sorted by name for stability.
-func datapointsFromMetric(m telegraf.Metric, tags map[string]string) []producers.Datapoint {
+func datapointsFromMetric(m telegraf.Metric, prefix string, tags map[string]string) []producers.Datapoint {
 	fields := m.Fields()
 	timestamp := timestampFromMetric(m)
 
@@ -467,8 +469,16 @@ func datapointsFromMetric(m telegraf.Metric, tags map[string]string) []producers
 
 	datapoints := make([]producers.Datapoint, len(fns))
 	for i, fn := range fns {
+		// If we have a single metric field whose name is value, omit it from the complete field name.
+		var name string
+		if len(fns) == 1 && fn == "value" {
+			name = prefix
+		} else {
+			name = prefix + "." + fn
+		}
+
 		datapoints[i] = producers.Datapoint{
-			Name:      fn,
+			Name:      name,
 			Value:     fields[fn],
 			Timestamp: timestamp,
 			Tags:      tags,

--- a/plugins/outputs/dcos_metrics/translator_test.go
+++ b/plugins/outputs/dcos_metrics/translator_test.go
@@ -463,7 +463,7 @@ func TestTranslate(t *testing.T) {
 				},
 				Datapoints: []producers.Datapoint{
 					producers.Datapoint{
-						Name:      "metric1",
+						Name:      "dcos.metrics.container.metric1",
 						Value:     uint64(0),
 						Timestamp: timestamp,
 						Tags: map[string]string{
@@ -472,7 +472,7 @@ func TestTranslate(t *testing.T) {
 						},
 					},
 					producers.Datapoint{
-						Name:      "metric2",
+						Name:      "dcos.metrics.container.metric2",
 						Value:     uint64(1),
 						Timestamp: timestamp,
 						Tags: map[string]string{
@@ -496,14 +496,13 @@ func TestTranslate(t *testing.T) {
 					"label_name":   "label_value",
 				},
 				fields: map[string]interface{}{
-					"metric1": uint64(0),
-					"metric2": uint64(1),
+					"value": uint64(0),
 				},
 				tm: tm,
 				tp: telegraf.Untyped,
 			},
 			output: producers.MetricsMessage{
-				Name: "dcos.metrics.app",
+				Name: "dcos.metrics.app.foo",
 				Dimensions: producers.Dimensions{
 					MesosID:       translator.MesosID,
 					ClusterID:     translator.DCOSClusterID,
@@ -514,14 +513,8 @@ func TestTranslate(t *testing.T) {
 				},
 				Datapoints: []producers.Datapoint{
 					producers.Datapoint{
-						Name:      "metric1",
+						Name:      "dcos.metrics.app.foo",
 						Value:     uint64(0),
-						Timestamp: timestamp,
-						Tags:      map[string]string{"label_name": "label_value"},
-					},
-					producers.Datapoint{
-						Name:      "metric2",
-						Value:     uint64(1),
 						Timestamp: timestamp,
 						Tags:      map[string]string{"label_name": "label_value"},
 					},

--- a/plugins/outputs/dcos_metrics/translator_test.go
+++ b/plugins/outputs/dcos_metrics/translator_test.go
@@ -485,6 +485,56 @@ func TestTranslate(t *testing.T) {
 		},
 
 		testCase{
+			name: "container metric with empty executor_name",
+			input: metricParams{
+				name: "prefix.foo",
+				tags: map[string]string{
+					"container_id":  "cid",
+					"service_name":  "sname",
+					"task_name":     "tname",
+					"executor_name": "",
+					"label_name":    "label_value",
+				},
+				fields: map[string]interface{}{
+					"metric1": uint64(0),
+					"metric2": uint64(1),
+				},
+				tm: tm,
+				tp: telegraf.Untyped,
+			},
+			output: producers.MetricsMessage{
+				Name: "dcos.metrics.container",
+				Dimensions: producers.Dimensions{
+					MesosID:       translator.MesosID,
+					ClusterID:     translator.DCOSClusterID,
+					Hostname:      translator.DCOSNodePrivateIP,
+					ContainerID:   "cid",
+					FrameworkName: "sname",
+					TaskName:      "tname",
+					Labels:        map[string]string{"label_name": "label_value"},
+				},
+				Datapoints: []producers.Datapoint{
+					producers.Datapoint{
+						Name:      "dcos.metrics.container.metric1",
+						Value:     uint64(0),
+						Timestamp: timestamp,
+						Tags: map[string]string{
+							"container_id": "cid",
+						},
+					},
+					producers.Datapoint{
+						Name:      "dcos.metrics.container.metric2",
+						Value:     uint64(1),
+						Timestamp: timestamp,
+						Tags: map[string]string{
+							"container_id": "cid",
+						},
+					},
+				},
+			},
+		},
+
+		testCase{
 			name: "app metric",
 			input: metricParams{
 				name: "prefix.foo",


### PR DESCRIPTION
* Include complete metric names in MetricMessage datapoints
* Strip "value" from metric names for app metrics
* Omit empty executor_name tags
* Improve sample config