### PR TITLE
Fix null value issue in dcos_metrics output

### DIFF
--- a/plugins/outputs/dcos_metrics/dcos_metrics_test.go
+++ b/plugins/outputs/dcos_metrics/dcos_metrics_test.go
@@ -152,9 +152,8 @@ func setupDCOSMetrics() (DCOSMetrics, string, error) {
 		DCOSNodePrivateIP: "10.0.0.1",
 	}
 
-	if err := dm.Start(); err != nil {
-		return dm, serverURL, err
-	}
+	return dm, serverURL, dm.Start()
+}
 
 // findFreePort momentarily listens on :0, then closes the connection and
 // returns the port assigned
@@ -162,7 +161,6 @@ func findFreePort() int {
 	ln, _ := net.Listen("tcp", ":0")
 	ln.Close()
 
-	return dm, serverURL, nil
 	addr := ln.Addr().(*net.TCPAddr)
 	return addr.Port
 }

--- a/plugins/outputs/dcos_metrics/dcos_metrics_test.go
+++ b/plugins/outputs/dcos_metrics/dcos_metrics_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"math"
+	"net"
 	"net/http"
 	"testing"
 	"time"
@@ -139,7 +140,7 @@ func TestDCOSMetricsNaNValue(t *testing.T) {
 }
 
 func setupDCOSMetrics() (DCOSMetrics, string, error) {
-	serverHostPort := "localhost:50001"
+	serverHostPort := fmt.Sprintf("localhost:%d", findFreePort())
 	serverURL := fmt.Sprintf("http://%s", serverHostPort)
 
 	dm := DCOSMetrics{
@@ -155,5 +156,13 @@ func setupDCOSMetrics() (DCOSMetrics, string, error) {
 		return dm, serverURL, err
 	}
 
+// findFreePort momentarily listens on :0, then closes the connection and
+// returns the port assigned
+func findFreePort() int {
+	ln, _ := net.Listen("tcp", ":0")
+	ln.Close()
+
 	return dm, serverURL, nil
+	addr := ln.Addr().(*net.TCPAddr)
+	return addr.Port
 }

--- a/plugins/outputs/dcos_metrics/translator_test.go
+++ b/plugins/outputs/dcos_metrics/translator_test.go
@@ -631,6 +631,8 @@ func TestTranslate(t *testing.T) {
 				t.Fatal("translation failed to produce a MetricsMessage")
 			}
 			if !reflect.DeepEqual(msg, tc.output) {
+				t.Log("expected:", tc.output)
+				t.Log("actually:", msg)
 				t.Fatal("translation returned an unexpected MetricsMessage")
 			}
 		})

--- a/plugins/outputs/dcos_metrics/translator_test.go
+++ b/plugins/outputs/dcos_metrics/translator_test.go
@@ -619,6 +619,93 @@ func TestTranslate(t *testing.T) {
 				},
 			},
 		},
+
+		// System metrics may sometimes be missing. Those metrics should not be transmitted as nil.
+		testCase{
+			name: "system metrics with missing values",
+			input: metricParams{
+				name: "system",
+				fields: map[string]interface{}{
+					"load1":  uint64(123),
+					"load5":  uint64(1234),
+					"load15": uint64(12345),
+					// uptime would be expected here, but is missing
+				},
+				tm: tm,
+				tp: telegraf.Untyped,
+			},
+			output: producers.MetricsMessage{
+				Name: "dcos.metrics.node",
+				Dimensions: producers.Dimensions{
+					MesosID:   translator.MesosID,
+					ClusterID: translator.DCOSClusterID,
+					Hostname:  translator.DCOSNodePrivateIP,
+				},
+				Datapoints: []producers.Datapoint{
+					producers.Datapoint{
+						Name:      "load.1min",
+						Value:     uint64(123),
+						Unit:      "count",
+						Timestamp: timestamp,
+					},
+					producers.Datapoint{
+						Name:      "load.5min",
+						Value:     uint64(1234),
+						Unit:      "count",
+						Timestamp: timestamp,
+					},
+					producers.Datapoint{
+						Name:      "load.15min",
+						Value:     uint64(12345),
+						Unit:      "count",
+						Timestamp: timestamp,
+					},
+				},
+			},
+		},
+
+		// Network metrics may sometimes be missing. Those metrics should not be transmitted as nil.
+		testCase{
+			name: "network metrics with missing values",
+			input: metricParams{
+				name: "net",
+				fields: map[string]interface{}{
+					"bytes_recv": uint64(123),
+					"bytes_sent": uint64(1234),
+					// several other metrics are missing
+				},
+				tags: map[string]string{
+					"interface":  "dummy",
+					"irrelevant": "foo",
+				},
+				tm: tm,
+				tp: telegraf.Untyped,
+			},
+			output: producers.MetricsMessage{
+				Name: "dcos.metrics.node",
+				Dimensions: producers.Dimensions{
+					MesosID:   translator.MesosID,
+					ClusterID: translator.DCOSClusterID,
+					Hostname:  translator.DCOSNodePrivateIP,
+				},
+				Datapoints: []producers.Datapoint{
+					producers.Datapoint{
+						Name:      "network.in",
+						Value:     uint64(123),
+						Unit:      "bytes",
+						Timestamp: timestamp,
+						Tags:      map[string]string{"interface": "dummy"},
+					},
+					producers.Datapoint{
+						Name:      "network.out",
+						Value:     uint64(1234),
+						Unit:      "bytes",
+						Timestamp: timestamp,
+						Tags:      map[string]string{"interface": "dummy"},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Values could sometimes be null in the v0 API because multiple messages were being processed, only some of which had field values set. Eg the 'system' metric was sent three times, once with 'uptime', once with 'load1', 'load5', and 'load15' but _not_ 'uptime', and once with none of the four. 

As they were processed in order, they were always nil. 

This PR adjusts the behaviour so that fields are only set if the value is non-nil. 

Fixes https://jira.mesosphere.com/browse/DCOS-41559
Fixes https://jira.mesosphere.com/browse/DCOS-41559