### PR TITLE
dcos_statsd: Use "." as metric separator

### DIFF
--- a/plugins/inputs/dcos_statsd/dcos_statsd.go
+++ b/plugins/inputs/dcos_statsd/dcos_statsd.go
@@ -186,6 +186,7 @@ func (ds *DCOSStatsd) AddContainer(ctr containers.Container) (*containers.Contai
 		ServiceAddress:         fmt.Sprintf(":%d", ctr.StatsdPort),
 		ParseDataDogTags:       true,
 		AllowedPendingMessages: 10000,
+		MetricSeparator:        ".",
 	}
 
 	// statsd will crash the whole Telegraf process if it attempts to listen on

--- a/plugins/inputs/dcos_statsd/dcos_statsd_test.go
+++ b/plugins/inputs/dcos_statsd/dcos_statsd_test.go
@@ -167,7 +167,7 @@ func TestGather(t *testing.T) {
 
 	// Tests for the existence of these stats are run in TestGatherUDP
 	// as they do not regularly pass on CI. Invoke them via
-	// go test -tag udp
+	// go test -tags udp
 
 	t.Log("Containers are persisted to disk")
 	files, err := ioutil.ReadDir(ds.ContainersDir)

--- a/plugins/inputs/dcos_statsd/dcos_statsd_udp_test.go
+++ b/plugins/inputs/dcos_statsd/dcos_statsd_udp_test.go
@@ -54,8 +54,8 @@ func TestGatherUDP(t *testing.T) {
 
 	// Send each count ten times to each server
 	for i := 0; i < 10; i++ {
-		abcconn.Write([]byte("foo:123|c"))
-		xyzconn.Write([]byte("foo:123|c"))
+		abcconn.Write([]byte("foo.bar:123|c"))
+		xyzconn.Write([]byte("foo.bar:123|c"))
 	}
 
 	abcconn.Close()
@@ -73,7 +73,7 @@ func TestGatherUDP(t *testing.T) {
 			var rawVal interface{}
 			var val int64
 			var ok bool
-			if p.Measurement != "foo" {
+			if p.Measurement != "foo.bar" {
 				continue
 			}
 			if cid, ok = p.Tags["container_id"]; !ok {


### PR DESCRIPTION
This changes the dcos_statsd input plugin to use `.` to separate fields in metric names, instead of `_`.

https://jira.mesosphere.com/browse/DCOS_OSS-4071