### PR TITLE
Update dcos_metadata plugin to honor nested container IDs properly

### DIFF
--- a/plugins/processors/dcos_metadata/dcos_metadata.go
+++ b/plugins/processors/dcos_metadata/dcos_metadata.go
@@ -230,11 +230,8 @@ func getContainerID(statuses []mesos.TaskStatus) string {
 	// Container ID is held in task status
 	for _, s := range statuses {
 		if cs := s.GetContainerStatus(); cs != nil {
+			// TODO (philipnrmn) account for deeply-nested containers
 			if cid := cs.GetContainerID(); cid != nil {
-				// TODO (philipnrmn) account for deeply-nested containers
-				if p := cid.GetParent(); p != nil {
-					return p.GetValue()
-				}
 				return cid.GetValue()
 			}
 		}

--- a/plugins/processors/dcos_metadata/dcos_metadata_test.go
+++ b/plugins/processors/dcos_metadata/dcos_metadata_test.go
@@ -115,14 +115,14 @@ var (
 			fixture: "nested",
 			inputs: []telegraf.Metric{
 				newMetric("test",
-					map[string]string{"container_id": "xyz123"},
+					map[string]string{"container_id": "abc123"},
 					map[string]interface{}{"value": int64(1)},
 					time.Now(),
 				),
 			},
 			expected: []telegraf.Metric{
 				newMetric("test",
-					map[string]string{"container_id": "xyz123"},
+					map[string]string{"container_id": "abc123"},
 					map[string]interface{}{"value": int64(1)},
 					time.Now(),
 				),
@@ -130,7 +130,7 @@ var (
 			cachedContainers: map[string]containerInfo{},
 			// We do not expect the cache to be updated
 			containers: map[string]containerInfo{
-				"xyz123": containerInfo{"xyz123", "task", "executor", "framework",
+				"abc123": containerInfo{"abc123", "task", "executor", "framework",
 					map[string]string{}},
 			},
 		},


### PR DESCRIPTION
Prevously, we were replacing the container ID of any nested containers
with the container ID of their parent as the index into the metrics
cache. This essentially meant that all nested containers were rolled up
under the same container ID of their parent in the metrics cache. This
commit fixes this.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
