### PR TITLE
Fix race in dcos_metrics test

### DIFF
--- a/plugins/outputs/dcos_metrics/dcos_metrics_test.go
+++ b/plugins/outputs/dcos_metrics/dcos_metrics_test.go
@@ -2,6 +2,7 @@ package dcos_metrics
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"math"
@@ -83,6 +84,11 @@ func TestDCOSMetricsNaNValue(t *testing.T) {
 	}
 	defer dcosMetrics.Stop()
 
+	waitFor(func() bool {
+		_, err := http.Get(url + "/health")
+		return err == nil
+	})
+
 	m, err := metric.New(
 		"prefix.foo",
 		map[string]string{
@@ -148,6 +154,11 @@ func TestDCOSMetricsNilValue(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer dcosMetrics.Stop()
+
+	waitFor(func() bool {
+		_, err := http.Get(url + "/health")
+		return err == nil
+	})
 
 	m1, err := metric.New(
 		"dcos.metrics.node.system",
@@ -224,4 +235,26 @@ func findFreePort() int {
 
 	addr := ln.Addr().(*net.TCPAddr)
 	return addr.Port
+}
+
+// waitFor waits five seconds for a condition to be true
+func waitFor(cond func() bool) error {
+	done := make(chan bool)
+
+	go func() {
+		for {
+			if cond() {
+				done <- true
+				break
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+	}()
+
+	select {
+	case <-done:
+		return nil
+	case <-time.After(30 * time.Second):
+		return errors.New("timed out waiting for condition")
+	}
 }

--- a/plugins/outputs/dcos_metrics/dcos_metrics_test.go
+++ b/plugins/outputs/dcos_metrics/dcos_metrics_test.go
@@ -254,7 +254,7 @@ func waitFor(cond func() bool) error {
 	select {
 	case <-done:
 		return nil
-	case <-time.After(30 * time.Second):
+	case <-time.After(5 * time.Second):
 		return errors.New("timed out waiting for condition")
 	}
 }

--- a/plugins/outputs/dcos_metrics/dcos_metrics_test.go
+++ b/plugins/outputs/dcos_metrics/dcos_metrics_test.go
@@ -84,10 +84,13 @@ func TestDCOSMetricsNaNValue(t *testing.T) {
 	}
 	defer dcosMetrics.Stop()
 
-	waitFor(func() bool {
+	err = waitFor(func() bool {
 		_, err := http.Get(url + "/health")
 		return err == nil
 	})
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	m, err := metric.New(
 		"prefix.foo",
@@ -155,10 +158,13 @@ func TestDCOSMetricsNilValue(t *testing.T) {
 	}
 	defer dcosMetrics.Stop()
 
-	waitFor(func() bool {
+	err = waitFor(func() bool {
 		_, err := http.Get(url + "/health")
 		return err == nil
 	})
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	m1, err := metric.New(
 		"dcos.metrics.node.system",


### PR DESCRIPTION
Tests now wait for the dcos_metrics server to come online. Tests were failing
before this change, because although the HTTPProducer had started, it was not
yet serving the API.
