### PR TITLE
Pool connections to the mesos operator API

### DIFF
--- a/plugins/inputs/dcos_containers/dcos_containers_test.go
+++ b/plugins/inputs/dcos_containers/dcos_containers_test.go
@@ -154,6 +154,15 @@ func TestSetIfNotNil(t *testing.T) {
 	})
 }
 
+func TestGetClient(t *testing.T) {
+	dc := DCOSContainers{}
+	client1, err1 := dc.getClient()
+	client2, err2 := dc.getClient()
+	assert.Nil(t, err1)
+	assert.Nil(t, err2)
+	assert.Equal(t, client1, client2)
+}
+
 // assertHasTimestamp checks that the specified measurement has the expected ts
 func assertHasTimestamp(t *testing.T, acc *testutil.Accumulator, measurement string, ts int64) {
 	expected := time.Unix(ts, 0)

--- a/plugins/processors/dcos_metadata/dcos_metadata_test.go
+++ b/plugins/processors/dcos_metadata/dcos_metadata_test.go
@@ -197,6 +197,15 @@ func TestApply(t *testing.T) {
 	}
 }
 
+func TestGetClient(t *testing.T) {
+	dm := DCOSMetadata{}
+	client1, err1 := dm.getClient()
+	client2, err2 := dm.getClient()
+	assert.Nil(t, err1)
+	assert.Nil(t, err2)
+	assert.Equal(t, client1, client2)
+}
+
 // newMetric is a convenience method which allows us to define test cases at
 // package level without doing error handling
 func newMetric(name string, tags map[string]string, fields map[string]interface{}, tm time.Time) telegraf.Metric {


### PR DESCRIPTION
This commit ensures that we use a single transport in each plugin which calls the mesos operator API.

Previously, we created a fresh transport on each call. As the default transport configuration keeps several connections open in order to re-use them, this led to hanging TCP connections which could eventually overwhelm mesos and crash an agent. 

 - Fixes [DCOS-42339](https://jira.mesosphere.com/browse/DCOS-42339) - More than 500.000 open TCP connections between mesos agents and dcos telegraf.]