### PR TITLE
Do not log error when mesos containers endpoint is empty

### DIFF
--- a/plugins/inputs/dcos_containers/dcos_containers.go
+++ b/plugins/inputs/dcos_containers/dcos_containers.go
@@ -2,7 +2,6 @@ package dcos_containers
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -127,7 +126,7 @@ func (dc *DCOSContainers) getContainers(ctx context.Context, cli calls.Sender) (
 
 	gc := r.GetGetContainers()
 	if gc == nil {
-		return gc, errors.New("the getContainers response from the mesos agent was empty")
+		return &agent.Response_GetContainers{Containers: []agent.Response_GetContainers_Container{}}, nil
 	}
 
 	return gc, nil


### PR DESCRIPTION
We were returning an error to Telegraf when the getContainers response from Mesos contained a nil value for `Containers`. Unfortunately this is the default case when the agent is idle, so on startup an agent's logs were full of misleading errors. 

We now replace a nil `Containers` with an empty array and do not give an error. 

Sample error which no longer exists:
```
Sep 25 20:14:00 ip-1-2-3-4.secret-zone.compute.internal start_telegraf.sh[5867]: 2018-09-25T20:14:00Z E! Error in plugin [inputs.dcos_containers]: the getContainers response from the mesos agent was empty
```
 - Fixes [DCOS_OSS-4180](https://jira.mesosphere.com/browse/DCOS_OSS-4180) - Downgrade 'empty containers' error to info
