### PR TITLE
Update golint package reference

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ all:
 	$(MAKE) telegraf
 
 deps:
-	go get -u github.com/golang/lint/golint
+	go get -u golang.org/x/lint/golint
 	go get github.com/sparrc/gdm
 	gdm restore --parallel=false
 


### PR DESCRIPTION
This change fixes the `deps` target. Without this change, `make deps`
fails with this error:

```
package github.com/golang/lint/golint: code in directory /Users/branden/.go/src/github.com/golang/lint/golint expects import "golang.org/x/lint/golint"
```

https://jira.mesosphere.com/browse/DCOS-43554

DC/OS PR: https://github.com/dcos/dcos/pull/3619