### PR TITLE
Lowercase processor plugin

### DIFF
--- a/plugins/processors/all/all.go
+++ b/plugins/processors/all/all.go
@@ -3,6 +3,7 @@ package all
 import (
 	_ "github.com/influxdata/telegraf/plugins/processors/converter"
 	_ "github.com/influxdata/telegraf/plugins/processors/dcos_metadata"
+	_ "github.com/influxdata/telegraf/plugins/processors/lowercase"
 	_ "github.com/influxdata/telegraf/plugins/processors/override"
 	_ "github.com/influxdata/telegraf/plugins/processors/printer"
 	_ "github.com/influxdata/telegraf/plugins/processors/regex"

--- a/plugins/processors/lowercase/README.md
+++ b/plugins/processors/lowercase/README.md
@@ -1,6 +1,6 @@
 # Lowercase Processor Plugin
 
-The lowercase processor plugin ensures that metrics fields are lowercased. 
+The lowercase processor plugin ensures that metric names and fields are lowercase. 
 
 By default, metrics are coerced to lowercase. Optionally, metrics may be copied, so that the original metric is
 preserved and a lowercase copy is also emitted. 

--- a/plugins/processors/lowercase/README.md
+++ b/plugins/processors/lowercase/README.md
@@ -1,0 +1,20 @@
+# Lowercase Processor Plugin
+
+The lowercase processor plugin ensures that metrics fields are lowercased. 
+
+By default, metrics are coerced to lowercase. Optionally, metrics may be copied, so that the original metric is
+preserved and a lowercase copy is also emitted. 
+
+### Configuration:
+
+```toml
+# Coerce all metrics that pass through this filter to lowercase.
+[[processors.lowercase]]
+  ## Sends both Some_Metric and some_metric if true. 
+  ## If false, sends only some_metric.
+  # send_original = false
+```
+
+### Tags:
+
+No tags are applied by this processor.

--- a/plugins/processors/lowercase/lowercase.go
+++ b/plugins/processors/lowercase/lowercase.go
@@ -28,7 +28,8 @@ func (l *Lowercase) Description() string {
 }
 
 func (l *Lowercase) Apply(in ...telegraf.Metric) []telegraf.Metric {
-	out := []telegraf.Metric{}
+	out := make([]telegraf.Metric, 0, len(in))
+
 	for _, metric := range in {
 		// Optimisation: only test for uppercase metrics if we wish to
 		// preserve the original metric.

--- a/plugins/processors/lowercase/lowercase.go
+++ b/plugins/processors/lowercase/lowercase.go
@@ -39,6 +39,9 @@ func (l *Lowercase) Apply(in ...telegraf.Metric) []telegraf.Metric {
 				metric.AddField(strings.ToLower(key), value)
 			}
 		}
+		if strings.ContainsAny(metric.Name(), capitals) {
+			metric.SetName(strings.ToLower(metric.Name()))
+		}
 		out = append(out, metric)
 	}
 	return out

--- a/plugins/processors/lowercase/lowercase.go
+++ b/plugins/processors/lowercase/lowercase.go
@@ -1,0 +1,51 @@
+package lowercase
+
+import (
+	"strings"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/processors"
+)
+
+type Lowercase struct {
+	SendOriginal bool `toml:"send_original"`
+}
+
+const capitals = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+var sampleConfig = `
+  ## Sends both Some_Metric and some_metric if true. 
+  ## If false, sends only some_metric.
+  # send_original = false
+`
+
+func (l *Lowercase) SampleConfig() string {
+	return sampleConfig
+}
+
+func (l *Lowercase) Description() string {
+	return "Coerce all metrics that pass through this filter to lowercase."
+}
+
+func (l *Lowercase) Apply(in ...telegraf.Metric) []telegraf.Metric {
+	out := []telegraf.Metric{}
+	for _, metric := range in {
+		if l.SendOriginal {
+			out = append(out, metric.Copy())
+		}
+		for key, value := range metric.Fields() {
+			if strings.ContainsAny(key, capitals) {
+				metric.RemoveField(key)
+				metric.AddField(strings.ToLower(key), value)
+			}
+		}
+		out = append(out, metric)
+	}
+	return out
+}
+
+func init() {
+	processors.Add("lowercase", func() telegraf.Processor {
+		return &Lowercase{}
+	})
+}

--- a/plugins/processors/lowercase/lowercase_test.go
+++ b/plugins/processors/lowercase/lowercase_test.go
@@ -13,7 +13,7 @@ import (
 // By default, we don't send original metrics, only lowercased metrics
 func TestApply_Defaults(t *testing.T) {
 	input, err := metric.New(
-		"test",
+		"tEsT",
 		map[string]string{},
 		map[string]interface{}{
 			"lower_case": "abc123",
@@ -27,6 +27,7 @@ func TestApply_Defaults(t *testing.T) {
 	lc := Lowercase{}
 	output := lc.Apply(input)
 	assert.Equal(t, 1, len(output))
+	assert.Equal(t, "test", output[0].Name())
 	assert.Equal(t, map[string]interface{}{
 		"lower_case": "abc123",
 		"upper_case": "ABC123",
@@ -37,7 +38,7 @@ func TestApply_Defaults(t *testing.T) {
 // With SendOriginals enabled, we send original metrics, and also lowercased metrics
 func TestApply_SendOriginals(t *testing.T) {
 	input, err := metric.New(
-		"test",
+		"tEsT",
 		map[string]string{},
 		map[string]interface{}{
 			"lower_case": "abc123",
@@ -51,6 +52,8 @@ func TestApply_SendOriginals(t *testing.T) {
 	lc := Lowercase{SendOriginal: true}
 	output := lc.Apply(input)
 	assert.Equal(t, 2, len(output))
+	assert.Equal(t, "tEsT", output[0].Name())
+	assert.Equal(t, "test", output[1].Name())
 	assert.Equal(t, map[string]interface{}{
 		"lower_case": "abc123",
 		"UPPER_CASE": "ABC123",

--- a/plugins/processors/lowercase/lowercase_test.go
+++ b/plugins/processors/lowercase/lowercase_test.go
@@ -95,3 +95,27 @@ func BenchmarkStringsMatch(b *testing.B) {
 		strings.ContainsAny(input, uppers)
 	}
 }
+
+// The following two tests demonstrate that casting a string to lowercase
+// naively is ~2 times faster than casting it only if uppercase.
+
+func BenchmarkConditionalLowercase(b *testing.B) {
+	inputs := []string{"Hello, World", "hello, world"}
+	uppers := "ABCDEFGHIJKLNMNOPQRSTUVWXYZ"
+	for i := 0; i < b.N; i++ {
+		for _, input := range inputs {
+			if strings.ContainsAny(input, uppers) {
+				strings.ToLower(input)
+			}
+		}
+	}
+}
+
+func BenchmarkNaiveLowercase(b *testing.B) {
+	inputs := []string{"Hello, World", "hello, world"}
+	for i := 0; i < b.N; i++ {
+		for _, input := range inputs {
+			strings.ToLower(input)
+		}
+	}
+}

--- a/plugins/processors/lowercase/lowercase_test.go
+++ b/plugins/processors/lowercase/lowercase_test.go
@@ -6,64 +6,75 @@ import (
 	"testing"
 	"time"
 
+	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/metric"
 	"github.com/stretchr/testify/assert"
 )
 
-// By default, we don't send original metrics, only lowercased metrics
-func TestApply_Defaults(t *testing.T) {
-	input, err := metric.New(
-		"tEsT",
-		map[string]string{},
-		map[string]interface{}{
+var (
+	fields = map[string]map[string]interface{}{
+		"ChAnGeD": map[string]interface{}{
 			"lower_case": "abc123",
 			"UPPER_CASE": "ABC123",
 			"Mixed_Case": "Abc123",
 		},
-		time.Now(),
-	)
-	assert.Nil(t, err)
+		"unchanged": map[string]interface{}{
+			"lower_case": "abc123",
+		},
+	}
+)
+
+// By default, we don't send original metrics, only lowercased metrics
+func TestApply_Defaults(t *testing.T) {
+	inputs := make([]telegraf.Metric, 2)
+	inputs[0], _ = metric.New("ChAnGeD", map[string]string{}, fields["ChAnGeD"], time.Now())
+	inputs[1], _ = metric.New("unchanged", map[string]string{}, fields["unchanged"], time.Now())
 
 	lc := Lowercase{}
-	output := lc.Apply(input)
-	assert.Equal(t, 1, len(output))
-	assert.Equal(t, "test", output[0].Name())
+	output := lc.Apply(inputs...)
+	assert.Equal(t, 2, len(output))
+
+	assert.Equal(t, "changed", output[0].Name())
 	assert.Equal(t, map[string]interface{}{
 		"lower_case": "abc123",
 		"upper_case": "ABC123",
 		"mixed_case": "Abc123",
 	}, output[0].Fields())
+
+	assert.Equal(t, "unchanged", output[1].Name())
+	assert.Equal(t, map[string]interface{}{
+		"lower_case": "abc123",
+	}, output[1].Fields())
 }
 
-// With SendOriginals enabled, we send original metrics, and also lowercased metrics
+// With SendOriginals enabled, we send original metrics and also lowercased metrics
 func TestApply_SendOriginals(t *testing.T) {
-	input, err := metric.New(
-		"tEsT",
-		map[string]string{},
-		map[string]interface{}{
-			"lower_case": "abc123",
-			"UPPER_CASE": "ABC123",
-			"Mixed_Case": "Abc123",
-		},
-		time.Now(),
-	)
-	assert.Nil(t, err)
+	inputs := make([]telegraf.Metric, 2)
+	inputs[0], _ = metric.New("ChAnGeD", map[string]string{}, fields["ChAnGeD"], time.Now())
+	inputs[1], _ = metric.New("unchanged", map[string]string{}, fields["unchanged"], time.Now())
 
 	lc := Lowercase{SendOriginal: true}
-	output := lc.Apply(input)
-	assert.Equal(t, 2, len(output))
-	assert.Equal(t, "tEsT", output[0].Name())
-	assert.Equal(t, "test", output[1].Name())
+	output := lc.Apply(inputs...)
+	assert.Equal(t, 3, len(output))
+
+	assert.Equal(t, "ChAnGeD", output[0].Name())
 	assert.Equal(t, map[string]interface{}{
 		"lower_case": "abc123",
 		"UPPER_CASE": "ABC123",
 		"Mixed_Case": "Abc123",
 	}, output[0].Fields())
+
+	assert.Equal(t, "changed", output[1].Name())
 	assert.Equal(t, map[string]interface{}{
 		"lower_case": "abc123",
 		"upper_case": "ABC123",
 		"mixed_case": "Abc123",
 	}, output[1].Fields())
+
+	assert.Equal(t, "unchanged", output[2].Name())
+	assert.Equal(t, map[string]interface{}{
+		"lower_case": "abc123",
+	}, output[2].Fields())
 }
 
 // The following two tests demonstrate that using strings.ContainsAny is ~6

--- a/plugins/processors/lowercase/lowercase_test.go
+++ b/plugins/processors/lowercase/lowercase_test.go
@@ -1,0 +1,83 @@
+package lowercase
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/influxdata/telegraf/metric"
+	"github.com/stretchr/testify/assert"
+)
+
+// By default, we don't send original metrics, only lowercased metrics
+func TestApply_Defaults(t *testing.T) {
+	input, err := metric.New(
+		"test",
+		map[string]string{},
+		map[string]interface{}{
+			"lower_case": "abc123",
+			"UPPER_CASE": "ABC123",
+			"Mixed_Case": "Abc123",
+		},
+		time.Now(),
+	)
+	assert.Nil(t, err)
+
+	lc := Lowercase{}
+	output := lc.Apply(input)
+	assert.Equal(t, 1, len(output))
+	assert.Equal(t, map[string]interface{}{
+		"lower_case": "abc123",
+		"upper_case": "ABC123",
+		"mixed_case": "Abc123",
+	}, output[0].Fields())
+}
+
+// With SendOriginals enabled, we send original metrics, and also lowercased metrics
+func TestApply_SendOriginals(t *testing.T) {
+	input, err := metric.New(
+		"test",
+		map[string]string{},
+		map[string]interface{}{
+			"lower_case": "abc123",
+			"UPPER_CASE": "ABC123",
+			"Mixed_Case": "Abc123",
+		},
+		time.Now(),
+	)
+	assert.Nil(t, err)
+
+	lc := Lowercase{SendOriginal: true}
+	output := lc.Apply(input)
+	assert.Equal(t, 2, len(output))
+	assert.Equal(t, map[string]interface{}{
+		"lower_case": "abc123",
+		"UPPER_CASE": "ABC123",
+		"Mixed_Case": "Abc123",
+	}, output[0].Fields())
+	assert.Equal(t, map[string]interface{}{
+		"lower_case": "abc123",
+		"upper_case": "ABC123",
+		"mixed_case": "Abc123",
+	}, output[1].Fields())
+}
+
+// The following two tests demonstrate that using strings.ContainsAny is ~6
+// times faster than a compiled regexp MatchString.
+
+func BenchmarkRegexpMatch(b *testing.B) {
+	input := "hello, World"
+	uppers := regexp.MustCompile("[A-Z]")
+	for i := 0; i < b.N; i++ {
+		uppers.MatchString(input)
+	}
+}
+
+func BenchmarkStringsMatch(b *testing.B) {
+	input := "hello, World"
+	uppers := "ABCDEFGHIJKLNMNOPQRSTUVWXYZ"
+	for i := 0; i < b.N; i++ {
+		strings.ContainsAny(input, uppers)
+	}
+}


### PR DESCRIPTION
This PR adds a processor plugin which casts all uppercase metric fields to lowercase. Optionally, the original field may be preserved (ie both `Some_Metric` and `some_metric` would be sent). 

- Resolves [DCOS-43639](https://jira.mesosphere.com/browse/DCOS-43639)