### PR TITLE
Enable dcos_statsd race detector

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,11 +78,10 @@ test-all: fmtcheck vet
 	go test ./...
 
 test-race-dcos:
-	go test -race ./plugins/inputs/dcos_containers/
-	# The race detector reports data races for this plugin. See https://jira.mesosphere.com/browse/DCOS_OSS-4096.
-	#go test -race ./plugins/inputs/dcos_statsd/
-	go test -race ./plugins/outputs/dcos_metrics/
-	go test -race ./plugins/processors/dcos_metadata/
+	go test -v -race ./plugins/inputs/dcos_containers/
+	go test -v -race ./plugins/inputs/dcos_statsd/
+	go test -v -race ./plugins/outputs/dcos_metrics/
+	go test -v -race ./plugins/processors/dcos_metadata/
 
 package:
 	./scripts/build.py --package --platform=all --arch=all

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,6 @@ test-all: fmtcheck vet
 	go test ./...
 
 test-race-dcos:
-	go test -race ./plugins/inputs/dcos
 	go test -race ./plugins/inputs/dcos_containers/
 	# The race detector reports data races for this plugin. See https://jira.mesosphere.com/browse/DCOS_OSS-4096.
 	#go test -race ./plugins/inputs/dcos_statsd/


### PR DESCRIPTION
This PR removes a race condition in the `dcos_statsd` plugin and re-enables race detection for `dcos_statsd` in CI.

The race condition occurs when `dcos_statsd` accesses `Statsd.UDPlistener` in order to find its port. `Statsd` doesn't synchronize any of its accesses to `UDPlistener`, so there's no way for `dcos_statsd` to safely access it. The simplest fix I could come up with was to add a channel at `Statsd.ListenAddr` where the server's address can be retrieved, and alter its listen methods to send the server's address to that channel after it starts. I then updated `dcos_statsd` to retrieve the server address from `Statsd.ListenAddr`, rather than from `Statsd.UDPlistener`.

https://jira.mesosphere.com/browse/DCOS_OSS-4096