### PR TITLE
DCOS_OSS-4181: Cache executor containers

### DIFF
--- a/plugins/processors/dcos_metadata/dcos_metadata.go
+++ b/plugins/processors/dcos_metadata/dcos_metadata.go
@@ -252,7 +252,10 @@ func (dm *DCOSMetadata) getClient() (*httpcli.Client, error) {
 // Each status can have multiple container IDs. In DC/OS, there is a
 // one-to-one mapping between tasks and containers; however it is
 // possible to have nested containers. Therefore we use the first status, and
-// return its parent container ID if possible, along with its ID.
+// getContainerIDs retrieves the container ID and the parent container ID of a                                          
+// task from its TaskStatus. The container ID corresponds to the task's                                                 
+// container, the parent container ID corresponds to the task's executor's                                              
+// container. 
 func getContainerIDs(statuses []mesos.TaskStatus) (string, string) {
 	// Container ID is held in task status
 	for _, s := range statuses {

--- a/plugins/processors/dcos_metadata/dcos_metadata.go
+++ b/plugins/processors/dcos_metadata/dcos_metadata.go
@@ -181,7 +181,7 @@ func (dm *DCOSMetadata) cache(gs *agent.Response_GetState) error {
 	executorNames := mapExecutorNames(gs.GetGetExecutors())
 
 	for _, t := range gt.GetLaunchedTasks() {
-		pcid, cid := getContainerIDs(t.GetStatuses())
+		cid, pcid := getContainerIDs(t.GetStatuses())
 		eName := ""
 		// ExecutorID is _not_ guaranteed not to be nil (FrameworkID is)
 		if eid := t.GetExecutorID(); eid != nil {
@@ -252,10 +252,10 @@ func (dm *DCOSMetadata) getClient() (*httpcli.Client, error) {
 // Each status can have multiple container IDs. In DC/OS, there is a
 // one-to-one mapping between tasks and containers; however it is
 // possible to have nested containers. Therefore we use the first status, and
-// getContainerIDs retrieves the container ID and the parent container ID of a                                          
-// task from its TaskStatus. The container ID corresponds to the task's                                                 
-// container, the parent container ID corresponds to the task's executor's                                              
-// container. 
+// getContainerIDs retrieves the container ID and the parent container ID of a
+// task from its TaskStatus. The container ID corresponds to the task's
+// container, the parent container ID corresponds to the task's executor's
+// container.
 func getContainerIDs(statuses []mesos.TaskStatus) (string, string) {
 	// Container ID is held in task status
 	for _, s := range statuses {
@@ -263,9 +263,9 @@ func getContainerIDs(statuses []mesos.TaskStatus) (string, string) {
 			// TODO (philipnrmn) account for deeply-nested containers
 			if cid := cs.GetContainerID(); cid != nil {
 				if pcid := cid.GetParent(); pcid != nil {
-					return pcid.GetValue(), cid.GetValue()
+					return cid.GetValue(), pcid.GetValue()
 				}
-				return "", cid.GetValue()
+				return cid.GetValue(), ""
 			}
 		}
 	}

--- a/plugins/processors/dcos_metadata/dcos_metadata.go
+++ b/plugins/processors/dcos_metadata/dcos_metadata.go
@@ -247,11 +247,6 @@ func (dm *DCOSMetadata) getClient() (*httpcli.Client, error) {
 	return client, nil
 }
 
-// getContainerIDs retrieves the parent container ID (if existent) and the
-// container ID linked to this task. Task can have multiple statuses.
-// Each status can have multiple container IDs. In DC/OS, there is a
-// one-to-one mapping between tasks and containers; however it is
-// possible to have nested containers. Therefore we use the first status, and
 // getContainerIDs retrieves the container ID and the parent container ID of a
 // task from its TaskStatus. The container ID corresponds to the task's
 // container, the parent container ID corresponds to the task's executor's


### PR DESCRIPTION
https://jira.mesosphere.com/browse/DCOS_OSS-4181
This caches executor containers, which are pulled from a task's parent container id. This will avoid repeated Mesos requests on constant cache misses.