### PR TITLE
Add user_agent config to telegraf plugins

### DIFF
--- a/Godeps
+++ b/Godeps
@@ -14,7 +14,7 @@ github.com/couchbase/go-couchbase bfe555a140d53dc1adf390f1a1d4b0fd4ceadb28
 github.com/couchbase/gomemcached 4a25d2f4e1dea9ea7dd76dfd943407abf9b07d29
 github.com/couchbase/goutils 5823a0cbaaa9008406021dc5daf80125ea30bba6
 github.com/davecgh/go-spew 346938d642f2ec3594ed81d874461961cd0faa76
-github.com/dcos/dcos-go b2b2d14915a3e4e112ae93cad44c9e1997c9ff42
+github.com/dcos/dcos-go 737f1c7403bf2022436e201947576ba63bad2394
 github.com/dcos/dcos-metrics aa08dd7bd88e76dcc67d0171ea0ae30c5b818d83
 github.com/dgrijalva/jwt-go dbeaa9332f19a944acb5736b4456cfcc02140e29
 github.com/docker/docker f5ec1e2936dcbe7b5001c2b817188b095c700c27

--- a/plugins/inputs/dcos_containers/README.md
+++ b/plugins/inputs/dcos_containers/README.md
@@ -15,6 +15,8 @@ generate it using `telegraf --usage dcos_containers`.
   mesos_agent_url = "http://localhost:5051"
   ## The period after which requests to mesos agent should time out
   timeout = "10s"
+  ## The user agent to send with requests
+  user_agent = "telegraf-dcos-containers"
   ## Optional IAM configuration
   # ca_certificate_path = "/run/dcos/pki/CA/ca-bundle.crt"
   # iam_config_path = "/run/dcos/etc/dcos-telegraf/service_account.json"

--- a/plugins/inputs/mesos/README.md
+++ b/plugins/inputs/mesos/README.md
@@ -37,6 +37,8 @@ For more information, please check the [Mesos Observability Metrics](http://meso
   #   "tasks",
   #   "messages",
   # ]
+  ## The user agent to send with requests
+  user_agent = "telegraf-mesos"
 
   ## Optional TLS Config
   # tls_ca = "/etc/telegraf/ca.pem"

--- a/plugins/inputs/mesos/iam.go
+++ b/plugins/inputs/mesos/iam.go
@@ -15,6 +15,7 @@ import (
 type DCOSConfig struct {
 	CACertificatePath string `toml:"ca_certificate_path"`
 	IAMConfigPath     string `toml:"iam_config_path"`
+	UserAgent         string `toml:"user_agent"`
 }
 
 // transport returns a transport implementing http.RoundTripper
@@ -25,9 +26,20 @@ func (c *DCOSConfig) transport() (http.RoundTripper, error) {
 	}
 
 	if c.IAMConfigPath != "" {
-		rt, err := transport.NewRoundTripper(
-			tr,
-			transport.OptionReadIAMConfig(c.IAMConfigPath))
+		var rt http.RoundTripper
+		var err error
+		if c.UserAgent != "" {
+			rt, err = transport.NewRoundTripper(
+				tr,
+				transport.OptionReadIAMConfig(c.IAMConfigPath),
+				transport.OptionUserAgent(c.UserAgent),
+			)
+		} else {
+			rt, err = transport.NewRoundTripper(
+				tr,
+				transport.OptionReadIAMConfig(c.IAMConfigPath),
+			)
+		}
 		if err != nil {
 			return nil, err
 		}

--- a/plugins/inputs/mesos/mesos.go
+++ b/plugins/inputs/mesos/mesos.go
@@ -150,6 +150,8 @@ var sampleConfig = `
   #   "tasks",
   #   "messages",
   # ]
+  ## The user agent to send with requests
+  user_agent = "telegraf-mesos"
 
   ## Optional TLS Config
   # tls_ca = "/etc/telegraf/ca.pem"

--- a/plugins/processors/dcos_metadata/README.md
+++ b/plugins/processors/dcos_metadata/README.md
@@ -22,6 +22,8 @@ appropriate metadata in the form of DC/OS primitives.
   ## to each metric as tags; the prefix is stripped from the
   ## label when tagging
   whitelist_prefix = []
+  ## The user agent to send with requests
+  user_agent = "telegraf-dcos-metadata"
   ## Optional IAM configuration
   # ca_certificate_path = "/run/dcos/pki/CA/ca-bundle.crt"
   # iam_config_path = "/run/dcos/etc/dcos-telegraf/service_account.json"


### PR DESCRIPTION
https://jira.mesosphere.com/browse/DCOS_OSS-4522
Bumps dcos-go version and adds `user_agent` configs to the `mesos`, `dcos_containers` and `dcos_metadata` plugins. I think these three are the only ones here that use dcos-go transports