### PR TITLE
Modify --config-directory to accept list of directories

### DIFF
--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -34,7 +34,7 @@ var fQuiet = flag.Bool("quiet", false,
 var fTest = flag.Bool("test", false, "gather metrics, print them out, and exit")
 var fConfig = flag.String("config", "", "configuration file to load")
 var fConfigDirectory = flag.String("config-directory", "",
-	"directory containing additional *.conf files")
+	"directories (comma-delimited) containing additional *.conf files")
 var fVersion = flag.Bool("version", false, "display the version")
 var fSampleConfig = flag.Bool("sample-config", false,
 	"print out full sample configuration")
@@ -98,9 +98,10 @@ func reloadLoop(
 		}
 
 		if *fConfigDirectory != "" {
-			err = c.LoadDirectory(*fConfigDirectory)
-			if err != nil {
-				log.Fatal("E! " + err.Error())
+			for _, dir := range strings.Split(*fConfigDirectory, ",") {
+				if err := c.LoadDirectory(dir); err != nil {
+					log.Fatal("E! " + err.Error())
+				}
 			}
 		}
 		if !*fTest && len(c.Outputs) == 0 {

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -33,7 +33,7 @@ The location of the configuration file can be set via the `--config` command
 line flag.
 
 When the `--config-directory` command line flag is used files ending with
-`.conf` in the specified directory will also be included in the Telegraf
+`.conf` in the specified directory/directories will also be included in the Telegraf
 configuration.
 
 On most systems, the default locations are `/etc/telegraf/telegraf.conf` for

--- a/internal/usage.go
+++ b/internal/usage.go
@@ -15,7 +15,7 @@ The commands & flags are:
 
   --config <file>     configuration file to load
   --test              gather metrics once, print them to stdout, and exit
-  --config-directory  directory containing additional *.conf files
+  --config-directory  directories (comma-delimited) containing additional *.conf files
   --input-filter      filter the input plugins to enable, separator is :
   --output-filter     filter the output plugins to enable, separator is :
   --usage             print usage for a plugin, ie, 'telegraf --usage mysql'
@@ -31,7 +31,7 @@ Examples:
   # generate config with only cpu input & influxdb output plugins defined
   telegraf --input-filter cpu --output-filter influxdb config
 
-  # run a single telegraf collection, outputing metrics to stdout
+  # run a single telegraf collection, outputting metrics to stdout
   telegraf --config telegraf.conf --test
 
   # run telegraf with all plugins defined in config file


### PR DESCRIPTION
Surprisingly easy to modify telegraf to accept a list of config directories in the `--config-directory` option and load all the confs from them. I left the option name as is (vs `--config-directories`) to avoid this becoming a breaking change. I've tested this on a cluster ✅ . I didn't add tests because there were no existing test files, and would probably be a lot more work to add an entire test suite for this file. Let me know if I'm missing anything!