### PR TITLE
Account for prometheus app metrics

### DIFF
--- a/plugins/inputs/logparser/grok/grok_test.go
+++ b/plugins/inputs/logparser/grok/grok_test.go
@@ -972,6 +972,7 @@ func TestNewlineInPatterns(t *testing.T) {
 }
 
 func TestSyslogTimestamp(t *testing.T) {
+	currentYear := time.Now().Year()
 	tests := []struct {
 		name     string
 		line     string
@@ -980,17 +981,17 @@ func TestSyslogTimestamp(t *testing.T) {
 		{
 			name:     "two digit day of month",
 			line:     "Sep 25 09:01:55 value=42",
-			expected: time.Date(2018, time.September, 25, 9, 1, 55, 0, time.UTC),
+			expected: time.Date(currentYear, time.September, 25, 9, 1, 55, 0, time.UTC),
 		},
 		{
 			name:     "one digit day of month single space",
 			line:     "Sep 2 09:01:55 value=42",
-			expected: time.Date(2018, time.September, 2, 9, 1, 55, 0, time.UTC),
+			expected: time.Date(currentYear, time.September, 2, 9, 1, 55, 0, time.UTC),
 		},
 		{
 			name:     "one digit day of month double space",
 			line:     "Sep  2 09:01:55 value=42",
-			expected: time.Date(2018, time.September, 2, 9, 1, 55, 0, time.UTC),
+			expected: time.Date(currentYear, time.September, 2, 9, 1, 55, 0, time.UTC),
 		},
 	}
 	for _, tt := range tests {

--- a/plugins/outputs/dcos_metrics/translator.go
+++ b/plugins/outputs/dcos_metrics/translator.go
@@ -41,13 +41,17 @@ func (t *producerTranslator) Translate(metric telegraf.Metric) (msg producers.Me
 	// Container metrics
 	// We assume any metric with a container_id tag but without a metric_type tag is a container metric from the
 	// dcos_containers input.
-	case hasAllKeys(tags, []string{"container_id"}) && !hasAnyKeys(tags, []string{"metric_type"}):
+	case hasAllKeys(tags, []string{"container_id"}) && !hasAnyKeys(tags, []string{"metric_type", "url"}):
 		msg = t.containerMetricsMessage(metric)
 
 	// App metrics
 	// We assume any metric with both a container_id tag and a metric_type tag is an app metric from the dcos_statsd
 	// input.
 	case hasAllKeys(tags, []string{"container_id", "metric_type"}):
+		msg = t.appMetricsMessage(metric)
+
+	// We assume any metric with both a container_id tag and a url tag is an app metric from the prometheus input.
+	case hasAllKeys(tags, []string{"container_id", "url"}):
 		msg = t.appMetricsMessage(metric)
 
 	// Node metrics

--- a/plugins/outputs/dcos_metrics/translator.go
+++ b/plugins/outputs/dcos_metrics/translator.go
@@ -39,19 +39,16 @@ func (t *producerTranslator) Translate(metric telegraf.Metric) (msg producers.Me
 	ok = true
 	switch {
 	// Container metrics
-	// We assume any metric with a container_id tag but without a metric_type tag is a container metric from the
-	// dcos_containers input.
+	// We assume any metric with a container_id tag but without a metric_type tag or a url tag is a container metric from
+	// the dcos_containers input.
 	case hasAllKeys(tags, []string{"container_id"}) && !hasAnyKeys(tags, []string{"metric_type", "url"}):
 		msg = t.containerMetricsMessage(metric)
 
 	// App metrics
 	// We assume any metric with both a container_id tag and a metric_type tag is an app metric from the dcos_statsd
 	// input.
-	case hasAllKeys(tags, []string{"container_id", "metric_type"}):
-		msg = t.appMetricsMessage(metric)
-
 	// We assume any metric with both a container_id tag and a url tag is an app metric from the prometheus input.
-	case hasAllKeys(tags, []string{"container_id", "url"}):
+	case hasAllKeys(tags, []string{"container_id"}) && hasAnyKeys(tags, []string{"metric_type", "url"}):
 		msg = t.appMetricsMessage(metric)
 
 	// Node metrics


### PR DESCRIPTION
Mesos tasks may expose metrics via prometheus as an alternative to transmitting metrics via statsd (see
https://jira.mesosphere.com/browse/DCOS_OSS-3717). This PR allows the dcos_metrics output plugin to expose prometheus task metrics via the /v0/containers/<cid>/app endpoint.
