### PR TITLE
Set MetricsMessage timestamp to Now

### DIFF
--- a/plugins/outputs/dcos_metrics/translator.go
+++ b/plugins/outputs/dcos_metrics/translator.go
@@ -84,6 +84,7 @@ func (t *producerTranslator) Translate(metric telegraf.Metric) (msg producers.Me
 		ok = false
 	}
 
+	msg.Timestamp = time.Now().Unix()
 	return
 }
 


### PR DESCRIPTION
https://jira.mesosphere.com/browse/DCOS_OSS-4679
COPS ticket: https://jira.mesosphere.com/browse/DCOS_OSS-4622

Sets the timestamp to `Now` on `MetricsMessage`s which dcos-metrics pulls in to assess the age of the metric to determine if it should be expired. This fixes the COPS issue where intermittent 204s are happening in the dcos-metrics API; they happen every minute whenever the "janitor" cleanup process runs that expires cached metrics older than 2min. Since all of these metric timestamps are coming up as the 0 time value (00:00:00 1/1/1970), the age calculation (time.Now - zero time) is clearly greater than the cache expiry of 2min, which causes the entire cache to empty out --> 204s until `dcos-containers` repopulates the cache.