### PR TITLE
Mesos plugin hashing bug

### DIFF
--- a/plugins/inputs/mesos/mesos.go
+++ b/plugins/inputs/mesos/mesos.go
@@ -62,25 +62,25 @@ func (tf TaggedField) hash() string {
 	buffer := "tf"
 
 	if tf.FrameworkName != "" {
-		buffer += "_" + tf.FrameworkName
+		buffer += "_fr:" + tf.FrameworkName
 	}
 	if tf.CallType != "" {
-		buffer += "_" + tf.CallType
+		buffer += "_ct:" + tf.CallType
 	}
 	if tf.EventType != "" {
-		buffer += "_" + tf.EventType
+		buffer += "_et:" + tf.EventType
 	}
 	if tf.OperationType != "" {
-		buffer += "_" + tf.OperationType
+		buffer += "_ot:" + tf.OperationType
 	}
 	if tf.TaskState != "" {
-		buffer += "_" + tf.TaskState
+		buffer += "_ts:" + tf.TaskState
 	}
 	if tf.RoleName != "" {
-		buffer += "_" + tf.RoleName
+		buffer += "_rn:" + tf.RoleName
 	}
 	if tf.Resource != "" {
-		buffer += "_" + tf.Resource
+		buffer += "_r:" + tf.Resource
 	}
 
 	return buffer

--- a/plugins/inputs/mesos/mesos.go
+++ b/plugins/inputs/mesos/mesos.go
@@ -62,7 +62,7 @@ func (tf TaggedField) hash() string {
 	buffer := "tf"
 
 	if tf.FrameworkName != "" {
-		buffer += "_fr:" + tf.FrameworkName
+		buffer += "_fn:" + tf.FrameworkName
 	}
 	if tf.CallType != "" {
 		buffer += "_ct:" + tf.CallType

--- a/plugins/inputs/mesos/mesos_test.go
+++ b/plugins/inputs/mesos/mesos_test.go
@@ -187,6 +187,7 @@ func generateMetrics() {
 		"allocator/mesos/allocation_run_latency_ms/p999",
 		"allocator/mesos/allocation_run_latency_ms/p9999",
 		"allocator/mesos/roles/*/shares/dominant",
+		"allocator/mesos/roles/marathon/shares/dominant",
 		"allocator/mesos/event_queue_dispatches",
 		"allocator/mesos/offer_filters/roles/*/active",
 		"allocator/mesos/quota/roles/*/resources/disk/offered_or_allocated",
@@ -393,6 +394,9 @@ func TestMesosMaster(t *testing.T) {
 			"allocator/offer_filters/roles/active": masterMetrics["allocator/mesos/offer_filters/roles/*/active"],
 		},
 		{
+			"allocator/roles/shares/dominant": masterMetrics["allocator/mesos/roles/marathon/shares/dominant"],
+		},
+		{
 			"allocator/quota/roles/resources/offered_or_allocated": masterMetrics["allocator/mesos/quota/roles/*/resources/disk/offered_or_allocated"],
 			"allocator/quota/roles/resources/guarantee":            masterMetrics["allocator/mesos/quota/roles/*/resources/disk/guarantee"],
 		},
@@ -471,6 +475,13 @@ func TestMesosMaster(t *testing.T) {
 			"url":       masterTestServer.URL,
 			"role":      "master",
 			"state":     "leader",
+			"role_name": "marathon",
+		},
+		{
+			"server":    m.masterURLs[0].Hostname(),
+			"url":       masterTestServer.URL,
+			"role":      "master",
+			"state":     "leader",
 			"role_name": "*",
 			"resource":  "disk",
 		},
@@ -486,6 +497,12 @@ func TestMesosMaster(t *testing.T) {
 
 	for i := 0; i < len(frameworkFields); i++ {
 		acc.AssertContainsTaggedFields(t, "mesos", frameworkFields[i], frameworkTags[i])
+		for j := 0; j < len(frameworkFields); j++ {
+			if j == i {
+				continue
+			}
+			acc.AssertDoesNotContainsTaggedFields(t, "mesos", frameworkFields[j], frameworkTags[i])
+		}
 	}
 }
 

--- a/testutil/accumulator.go
+++ b/testutil/accumulator.go
@@ -303,9 +303,10 @@ func (a *Accumulator) AssertDoesNotContainsTaggedFields(
 			continue
 		}
 
-		if p.Measurement == measurement {
-			assert.Equal(t, fields, p.Fields)
-			msg := fmt.Sprintf("found measurement %s with tags %v which should not be there", measurement, tags)
+		if p.Measurement == measurement && reflect.DeepEqual(fields, p.Fields) {
+			msg := fmt.Sprintf(
+				"found measurement %s with tagged fields (tags %v) which should not be there",
+				measurement, tags)
 			assert.Fail(t, msg)
 		}
 	}


### PR DESCRIPTION
Fixes the hashing function to avoid potentially mapping fields to wrong tags, more details in [JIRA ticket](https://jira.mesosphere.com/browse/DCOS_OSS-4760)

I fixed the `AssertDoesNotContainsTaggedFields` method to do what the method name more accurately claims (and I needed it to make my tests more robust to catch this sort of bug 😬 ) I opened up a ticket against influxdata/telegraf with the same change https://github.com/influxdata/telegraf/pull/5365