### PR TITLE
Add dropped messages metric to the statsd input plugin

### DIFF
--- a/plugins/inputs/statsd/statsd.go
+++ b/plugins/inputs/statsd/statsd.go
@@ -130,6 +130,7 @@ type Statsd struct {
 	TotalConnections   selfstat.Stat
 	PacketsRecv        selfstat.Stat
 	BytesRecv          selfstat.Stat
+	DroppedMessages    selfstat.Stat
 
 	// A pool of byte slices to handle parsing
 	bufPool sync.Pool
@@ -319,6 +320,7 @@ func (s *Statsd) Start(_ telegraf.Accumulator) error {
 	s.TotalConnections = selfstat.Register("statsd", "tcp_total_connections", tags)
 	s.PacketsRecv = selfstat.Register("statsd", "tcp_packets_received", tags)
 	s.BytesRecv = selfstat.Register("statsd", "tcp_bytes_received", tags)
+	s.DroppedMessages = selfstat.Register("statsd", "dropped_messages", tags)
 
 	s.in = make(chan *bytes.Buffer, s.AllowedPendingMessages)
 	s.done = make(chan struct{})
@@ -856,6 +858,10 @@ func (s *Statsd) remember(id string, conn *net.TCPConn) {
 
 // reportDroppedMessage() updates counters and logs when an incoming message is dropped due to a full buffer.
 func (s *Statsd) reportDroppedMessage() {
+	// Increment external metric.
+	s.DroppedMessages.Incr(1)
+
+	// Increment internal counter and use it to decide whether to log this event.
 	s.drops++
 	if s.drops == 1 || s.AllowedPendingMessages == 0 || s.drops%s.AllowedPendingMessages == 0 {
 		log.Printf(dropwarn, s.drops)

--- a/plugins/inputs/statsd/statsd.go
+++ b/plugins/inputs/statsd/statsd.go
@@ -830,7 +830,7 @@ func (s *Statsd) handler(conn *net.TCPConn, id string) {
 			case s.in <- b:
 			default:
 				s.drops++
-				if s.drops == 1 || s.drops%s.AllowedPendingMessages == 0 {
+				if s.drops == 1 || s.AllowedPendingMessages == 0 || s.drops%s.AllowedPendingMessages == 0 {
 					log.Printf(dropwarn, s.drops)
 				}
 			}


### PR DESCRIPTION
This adds an internal metric to the statsd input: `internal_statsd_dropped_messages`. This metric reports the number of incoming metric messages that have been dropped due to a full queue. It is applicable to both UDP and TCP.

Tested manually as part of https://github.com/dcos/dcos/pull/4557.

https://jira.mesosphere.com/browse/DCOS_OSS-4759

DC/OS PR: https://github.com/dcos/dcos/pull/4557