### PR TITLE
Allow sockets to be managed with systemd

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,7 +2,7 @@
 
 
 [[projects]]
-  digest = "1:972f38a9c879a4920d1e3a3d3438104b6c06163bfa3e6f4064adb00468d40587"
+  digest = "1:458c53ff6ad6a0c7145bdd157bd691ab7c0eba7fffd346298efd48866af30bf0"
   name = "cloud.google.com/go"
   packages = [
     "civil",
@@ -16,14 +16,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:fc0802104acded1f48e4860a9f2db85b82b4a754fca9eae750ff4e8b8cdf2116"
+  digest = "1:d7582b4af1b0b953ff2bb9573a50f787c7e1669cb148fb086a3d1c670a1ac955"
   name = "code.cloudfoundry.org/clock"
   packages = ["."]
   pruneopts = ""
   revision = "02e53af36e6c978af692887ed449b74026d76fec"
 
 [[projects]]
-  digest = "1:ca3acef20fd660d4df327accbf3ca2df9a12213d914f3113305dcd56579324b9"
+  digest = "1:ce7dc0f1ffcd9a2aacc50ae6d322eebff8f4faa2d6c5f445c874cd0b77a63de7"
   name = "collectd.org"
   packages = [
     "api",
@@ -35,7 +35,7 @@
   version = "v0.3.0"
 
 [[projects]]
-  digest = "1:5f61d4466cef935862c262f6bc00e24beb5b39b551e906f3cfb180dfac096d57"
+  digest = "1:27225d855b839ce9c20e1a2291e4447f744effb952f9eb69ef1a313bf7acb458"
   name = "contrib.go.opencensus.io/exporter/stackdriver"
   packages = ["propagation"]
   pruneopts = ""
@@ -43,7 +43,7 @@
   version = "v0.6.0"
 
 [[projects]]
-  digest = "1:5923e22a060ab818a015593422f9e8a35b9d881d4cfcfed0669a82959b11c7ee"
+  digest = "1:24a65c080381654718032ec9cf23e6fbdb7d49dcdbd20de38428dc46480abff7"
   name = "github.com/Azure/go-autorest"
   packages = [
     "autorest",
@@ -58,7 +58,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:298712a3ee36b59c3ca91f4183bd75d174d5eaa8b4aed5072831f126e2e752f6"
+  digest = "1:c1269bfaddefd090935401c291ad5df6c03de605a440e941ecc568e19f0f9e3b"
   name = "github.com/Microsoft/ApplicationInsights-Go"
   packages = [
     "appinsights",
@@ -68,7 +68,7 @@
   revision = "d2df5d440eda5372f24fcac03839a64d6cb5f7e5"
 
 [[projects]]
-  digest = "1:45ec6eb579713a01991ad07f538fed3b576ee55f5ce9f248320152a9270d9258"
+  digest = "1:ec6a42cd98d70f0916216d8f6df8ca61145edeaad041014aa9c003068de7364c"
   name = "github.com/Microsoft/go-winio"
   packages = ["."]
   pruneopts = ""
@@ -76,7 +76,7 @@
   version = "v0.4.9"
 
 [[projects]]
-  digest = "1:213b41361ad1cb4768add9d26c2e27794c65264eefdb24ed6ea34cdfeeff3f3c"
+  digest = "1:0aa7e06b81acfb81926ea600988189f8e6416e4a2e63283393e09b04c3030205"
   name = "github.com/Shopify/sarama"
   packages = ["."]
   pruneopts = ""
@@ -92,7 +92,7 @@
   version = "1.0.0"
 
 [[projects]]
-  digest = "1:f296e8b29c60c94efed3b8cfae08d793cb95149cdd7343e6a9834b4ac7136475"
+  digest = "1:1e3d473b58cf20e01f6357acc559ca7d82b2298fc91d3ae0178feaf9b9444344"
   name = "github.com/aerospike/aerospike-client-go"
   packages = [
     ".",
@@ -113,7 +113,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:a74730e052a45a3fab1d310fdef2ec17ae3d6af16228421e238320846f2aaec8"
+  digest = "1:1399282ad03ac819f0e8a747c888407c5c98bb497d33821a7047c7bae667ede0"
   name = "github.com/alecthomas/template"
   packages = [
     ".",
@@ -132,7 +132,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:7f21a8f175ee7f91c659f919c61032e11889fba5dc25c0cec555087cbb87435a"
+  digest = "1:072692f8d76356228f31f64ca3140041a140011c7dea26e746206e8649c71b31"
   name = "github.com/amir/raidman"
   packages = [
     ".",
@@ -143,14 +143,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:0828d8c0f95689f832cf348fe23827feb7640cd698d612ef59e2f9d041f54c68"
+  digest = "1:83a67d925714169fa5121021abef0276605c6e4d51c467dd1f0c04344abad1ff"
   name = "github.com/apache/thrift"
   packages = ["lib/go/thrift"]
   pruneopts = ""
   revision = "f2867c24984aa53edec54a138c03db934221bdea"
 
 [[projects]]
-  digest = "1:996727880e06dcf037f712c4d046e241d1b1b01844636fefb0fbaa480cfd230e"
+  digest = "1:d447d11b4a3f12abdc7c1d381a4927919feb3acb72bf243738670f5f6306820c"
   name = "github.com/aws/aws-sdk-go"
   packages = [
     "aws",
@@ -191,14 +191,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:c0bec5f9b98d0bc872ff5e834fac186b807b656683bd29cb82fb207a1513fabb"
+  digest = "1:fca298802a2ab834d6eb0e284788ae037ebc324c0f325ff92c5eea592d189cc5"
   name = "github.com/beorn7/perks"
   packages = ["quantile"]
   pruneopts = ""
   revision = "3a771d992973f24aa725d07868b467d1ddfceafb"
 
 [[projects]]
-  digest = "1:c5978131c797af795972c27c25396c81d1bf53b7b6e8e3e0259e58375765c071"
+  digest = "1:0edb96edcfeee9aeba92e605536fbb1542b0bf6a10cea9d0b5a2227d5a703eae"
   name = "github.com/bsm/sarama-cluster"
   packages = ["."]
   pruneopts = ""
@@ -223,7 +223,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:298e42868718da06fc0899ae8fdb99c48a14477045234c9274d81caa79af6a8f"
+  digest = "1:65ae2d1625584ba8d16d1e15b25db1fc62334e2040f22dbbbdc7531c909843b2"
   name = "github.com/couchbase/go-couchbase"
   packages = ["."]
   pruneopts = ""
@@ -231,7 +231,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:c734658274a6be88870a36742fdea96a3fce4fc99a7b90946c9e84335ceae71a"
+  digest = "1:5db54de7054c072f47806c91ef7625ffa00489ca2da5fbc6ca1c78e08018f6bf"
   name = "github.com/couchbase/gomemcached"
   packages = [
     ".",
@@ -242,7 +242,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:c1195c02bc8fbf5307cfb95bc79eddaa1351ee3587cc4a7bbe6932e2fb966ff2"
+  digest = "1:0deaa0f28c823119725c8308703f019797bc077e251d1ed3f2b8eae2cc7791d7"
   name = "github.com/couchbase/goutils"
   packages = [
     "logging",
@@ -252,7 +252,7 @@
   revision = "e865a1461c8ac0032bd37e2d4dab3289faea3873"
 
 [[projects]]
-  digest = "1:56c130d885a4aacae1dd9c7b71cfe39912c7ebc1ff7d2b46083c8812996dc43b"
+  digest = "1:0a39ec8bf5629610a4bc7873a92039ee509246da3cef1a0ea60f1ed7e5f9cea5"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
   pruneopts = ""
@@ -264,7 +264,6 @@
   digest = "1:f409c9b273ad1b344aab73afab72a4e818e8a6f0cda815b70975f129ce774cc5"
   name = "github.com/dcos/dcos-go"
   packages = [
-    "dcos",
     "dcos/http/transport",
     "store",
   ]
@@ -284,7 +283,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:7fdc54859cd901c25b9d8db964410a4e0d98fa0dca267fe4cf49c0eede5e06c2"
+  digest = "1:900aebd16ee5bab8d0d06290b233a37149bab39fb3a967ebdbf871537f78f1a4"
   name = "github.com/denisenkom/go-mssqldb"
   packages = [
     ".",
@@ -294,7 +293,7 @@
   revision = "1eb28afdf9b6e56cf673badd47545f844fe81103"
 
 [[projects]]
-  digest = "1:6098222470fe0172157ce9bbef5d2200df4edde17ee649c5d6e48330e4afa4c6"
+  digest = "1:2426da75f49e5b8507a6ed5d4c49b06b2ff795f4aec401c106b7db8fb2625cd7"
   name = "github.com/dgrijalva/jwt-go"
   packages = ["."]
   pruneopts = ""
@@ -310,7 +309,7 @@
   revision = "6c6132ff69f0f6c088739067407b5d32c52e1d0f"
 
 [[projects]]
-  digest = "1:522eff2a1f014a64fb403db60fc0110653e4dc5b59779894d208e697b0708ddc"
+  digest = "1:68df19ee476d93359596377b7437bbe49d233fe014becd060ded757aeed531cd"
   name = "github.com/docker/distribution"
   packages = [
     "digestset",
@@ -320,7 +319,7 @@
   revision = "edc3ab29cdff8694dd6feb85cfeb4b5f1b38ed9c"
 
 [[projects]]
-  digest = "1:d149605f1b00713fdc48150122892d77d49d30c825f690dd92f497aeb6cf18f5"
+  digest = "1:a21509491bfd5bd1f99abe1d38430fddd16c8c8dc0092f954e224b93ad87f06b"
   name = "github.com/docker/docker"
   packages = [
     "api",
@@ -345,7 +344,7 @@
   revision = "ed7b6428c133e7c59404251a09b7d6b02fa83cc2"
 
 [[projects]]
-  digest = "1:a5ecc2e70260a87aa263811281465a5effcfae8a54bac319cee87c4625f04d63"
+  digest = "1:5b20afc76a36d3994194e2612e83b51bc2b12db3d4d2a722b24474b2d0e3a890"
   name = "github.com/docker/go-connections"
   packages = [
     "nat",
@@ -366,14 +365,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:809792497a26f3936462cc5787a0d644b4d3cbfd59587e4f8845a9396ca2eb8a"
+  digest = "1:a3834ba4be461d97f0473067d603d4dfc22472979d8f939001a4536eb6598724"
   name = "github.com/docker/libnetwork"
   packages = ["ipvs"]
   pruneopts = ""
   revision = "d7b61745d16675c9f548b19f06fda80d422a74f0"
 
 [[projects]]
-  digest = "1:6d6672f85a84411509885eaa32f597577873de00e30729b9bb0eb1e1faa49c12"
+  digest = "1:7bbb118aeef9a6b9fef3d57b6cc5378f7cd6e915cabf4dea695e318e1a1bd4e6"
   name = "github.com/eapache/go-resiliency"
   packages = ["breaker"]
   pruneopts = ""
@@ -382,7 +381,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:7b12ea8b50040c6c2378ec5b5a1ab722730b2bfb46e8724ded57f2c3905431fa"
+  digest = "1:7b28f7f7c9fb914b30dff111fb910d49bd61d275101f665aea79409bb3ba2ae2"
   name = "github.com/eapache/go-xerial-snappy"
   packages = ["."]
   pruneopts = ""
@@ -397,7 +396,7 @@
   version = "v1.1.0"
 
 [[projects]]
-  digest = "1:3fa846cb3feb4e65371fe3c347c299de9b5bc3e71e256c0d940cd19b767a6ba0"
+  digest = "1:d2e2aebcb8e8027345e16f9d0be8cdee3bb470ba406c7a54cb7457ae3ad4ace5"
   name = "github.com/eclipse/paho.mqtt.golang"
   packages = [
     ".",
@@ -408,7 +407,7 @@
   version = "v1.1.1"
 
 [[projects]]
-  digest = "1:99a0607f79d36202b64b674c0464781549917cfc4bfb88037aaa98b31e124a18"
+  digest = "1:906fec62fafe17484a101277d58834d3f737b07dc82255ed30e5ce306cfb28b3"
   name = "github.com/ericchiang/k8s"
   packages = [
     ".",
@@ -426,7 +425,7 @@
   version = "v1.2.0"
 
 [[projects]]
-  digest = "1:858b7fe7b0f4bc7ef9953926828f2816ea52d01a88d72d1c45bc8c108f23c356"
+  digest = "1:d19c78214e03e297e9e30d2eb11892f731358b2951f2a5c7374658a156373e4c"
   name = "github.com/go-ini/ini"
   packages = ["."]
   pruneopts = ""
@@ -442,7 +441,7 @@
   version = "v0.3.0"
 
 [[projects]]
-  digest = "1:96c4a6ff4206086347bfe28e96e092642882128f45ecb8dc8f15f3e6f6703af0"
+  digest = "1:c3a5ae14424a38c244439732c31a08b5f956c46c4acdc159fc285a52dbf11de0"
   name = "github.com/go-ole/go-ole"
   packages = [
     ".",
@@ -453,7 +452,7 @@
   version = "v1.2.1"
 
 [[projects]]
-  digest = "1:3dfd659219b6f63dc0677a62b8d4e8f10b5cf53900aef40858db10a19407e41d"
+  digest = "1:f2f6a616a1ca8aed667d956c98f7f6178efe72bbe0a419bd33b9d99841c7de69"
   name = "github.com/go-redis/redis"
   packages = [
     ".",
@@ -470,7 +469,7 @@
   version = "v6.12.0"
 
 [[projects]]
-  digest = "1:c07de423ca37dc2765396d6971599ab652a339538084b9b58c9f7fc533b28525"
+  digest = "1:dc876ae7727280d95f97af5320308131278b93d6c6f5cf953065e18cb8c88fd2"
   name = "github.com/go-sql-driver/mysql"
   packages = ["."]
   pruneopts = ""
@@ -478,7 +477,7 @@
   version = "v1.4.0"
 
 [[projects]]
-  digest = "1:9ab1b1c637d7c8f49e39d8538a650d7eb2137b076790cff69d160823b505964c"
+  digest = "1:b7a7e17513aeee6492d93015c7bf29c86a0c1c91210ea56b21e36c1a40958cba"
   name = "github.com/gobwas/glob"
   packages = [
     ".",
@@ -495,7 +494,7 @@
   version = "v0.2.3"
 
 [[projects]]
-  digest = "1:6e73003ecd35f4487a5e88270d3ca0a81bc80dc88053ac7e4dcfec5fba30d918"
+  digest = "1:673df1d02ca0c6f51458fe94bbb6fae0b05e54084a31db2288f1c4321255c2da"
   name = "github.com/gogo/protobuf"
   packages = [
     "gogoproto",
@@ -507,7 +506,7 @@
   version = "v1.1.1"
 
 [[projects]]
-  digest = "1:f958a1c137db276e52f0b50efee41a1a389dcdded59a69711f3e872757dab34b"
+  digest = "1:b1d3041d568e065ab4d76f7477844458e9209c0bb241eaccdc0770bf0a13b120"
   name = "github.com/golang/protobuf"
   packages = [
     "proto",
@@ -526,14 +525,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:2a5888946cdbc8aa360fd43301f9fc7869d663f60d5eedae7d4e6e5e4f06f2bf"
+  digest = "1:075128b9fc42e6d99067da1a2e6c0a634a6043b5a60abe6909c51f5ecad37b6d"
   name = "github.com/golang/snappy"
   packages = ["."]
   pruneopts = ""
   revision = "2e65f85255dbc3072edf28d6b5b8efc472979f5a"
 
 [[projects]]
-  digest = "1:f9f45f75f332e03fc7e9fe9188ea4e1ce4d14779ef34fa1b023da67518e36327"
+  digest = "1:cc082d7b9cc3f832f2aed9d06d1cbb33b6984a61d8ec403535b086415c181607"
   name = "github.com/google/go-cmp"
   packages = [
     "cmp",
@@ -586,7 +585,7 @@
   revision = "e80d13ce29ede4452c43dea11e79b9bc8a15b478"
 
 [[projects]]
-  digest = "1:e7224669901bab4094e6d6697c136557b7177db6ceb01b7fc8b20d08f4b5aacd"
+  digest = "1:db58383b43f583c44fb47c3331de943a11bb73ea951c2def55d29a454a57f4ee"
   name = "github.com/hashicorp/consul"
   packages = ["api"]
   pruneopts = ""
@@ -603,14 +602,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:ff65bf6fc4d1116f94ac305342725c21b55c16819c2606adc8f527755716937f"
+  digest = "1:cd5813053beac0114f96a7da3924fc8a15e0cd2b139f079e0fcce5d3244ae304"
   name = "github.com/hashicorp/go-rootcerts"
   packages = ["."]
   pruneopts = ""
   revision = "6bb64b370b90e7ef1fa532be9e591a81c3493e00"
 
 [[projects]]
-  digest = "1:f72168ea995f398bab88e84bd1ff58a983466ba162fb8d50d47420666cd57fad"
+  digest = "1:d2b2cff454cb23a9769ef3c9075741f5985773a998584b3b3ce203fe4b1abbea"
   name = "github.com/hashicorp/serf"
   packages = ["coordinate"]
   pruneopts = ""
@@ -618,7 +617,7 @@
   version = "v0.8.1"
 
 [[projects]]
-  digest = "1:824c4cd143ee15735f1c75d9072aad46e51dd27a4ef8bf6ce723a138265b7fb3"
+  digest = "1:5f06302a83e41839076be3fd444dc3d977f5d842cda4fe4ec564ec46bd7d450c"
   name = "github.com/influxdata/go-syslog"
   packages = [
     ".",
@@ -632,7 +631,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:bc3eb5ddfd59781ea1183f2b3d1eb105a1495d421f09b2ccd360c7fced0b612d"
+  digest = "1:effc58ad45323ad15159bbca533be4870eaddb2d9a513d3488d8bfe822c83532"
   name = "github.com/influxdata/tail"
   packages = [
     ".",
@@ -646,7 +645,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:7fb6cc9607eaa6ef309edebc42b57f704244bd4b9ab23bff128829c4ad09b95d"
+  digest = "1:d31edcf33a3b36218de96e43f3fec18ea96deb2a28b838a3a01a4df856ded345"
   name = "github.com/influxdata/toml"
   packages = [
     ".",
@@ -664,7 +663,7 @@
   revision = "7c63b0a71ef8300adc255344d275e10e5c3a71ec"
 
 [[projects]]
-  digest = "1:5544f7badae00bc5b9ec6829857bc08f88fce4d3ef73fb616ee57d49abbf7f48"
+  digest = "1:c85686f4af10c394e14f7733d70b0a1c2f7715d08e2c339d0e7434f6fb69b8d5"
   name = "github.com/jackc/pgx"
   packages = [
     ".",
@@ -680,7 +679,7 @@
   version = "v3.2.0"
 
 [[projects]]
-  digest = "1:6f49eae0c1e5dab1dafafee34b207aeb7a42303105960944828c2079b92fc88e"
+  digest = "1:4f767a115bc8e08576f6d38ab73c376fc1b1cd3bb5041171c9e8668cc7739b52"
   name = "github.com/jmespath/go-jmespath"
   packages = ["."]
   pruneopts = ""
@@ -696,7 +695,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:fed90fa725d3b1bac0a760de64426834dfef4546474cf182f2ec94285afa74a8"
+  digest = "1:2df59f23f11c5c59982f737c98c5523b276bfc85a4773a04b411190402bb30fd"
   name = "github.com/kardianos/service"
   packages = ["."]
   pruneopts = ""
@@ -720,7 +719,7 @@
 
 [[projects]]
   branch = "develop"
-  digest = "1:3e66a61a57bbbe832c338edb3a623be0deb3dec650c2f3515149658898287e37"
+  digest = "1:60a2f9026a397e37db0f43e7dfa0c0424907f0b1a61e4cd6045e2aa916291921"
   name = "github.com/leodido/ragel-machinery"
   packages = [
     ".",
@@ -731,7 +730,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:7e9956922e349af0190afa0b6621befcd201072679d8e51a9047ff149f2afe93"
+  digest = "1:28ca57775f285ae87cbdc7280aad91c5f2ed3c2af98d9f035d75956d1ca97fe6"
   name = "github.com/mailru/easyjson"
   packages = [
     ".",
@@ -743,7 +742,7 @@
   revision = "efc7eb8984d6655c26b5c9d2e65c024e5767c37c"
 
 [[projects]]
-  digest = "1:63722a4b1e1717be7b98fc686e0b30d5e7f734b9e93d7dee86293b6deab7ea28"
+  digest = "1:49a8b01a6cd6558d504b65608214ca40a78000e1b343ed0da5c6a9ccd83d6d30"
   name = "github.com/matttproud/golang_protobuf_extensions"
   packages = ["pbutil"]
   pruneopts = ""
@@ -775,7 +774,7 @@
   version = "v0.0.8"
 
 [[projects]]
-  digest = "1:4c8d8358c45ba11ab7bb15df749d4df8664ff1582daead28bae58cf8cbe49890"
+  digest = "1:f0bad0fece0fb73c6ea249c18d8e80ffbe86be0457715b04463068f04686cf39"
   name = "github.com/miekg/dns"
   packages = ["."]
   pruneopts = ""
@@ -815,7 +814,7 @@
   version = "v0.1.0"
 
 [[projects]]
-  digest = "1:e5ec850ce66beb0014fc40d8e64b7482172eee71d86d734d66def5e9eac16797"
+  digest = "1:e5894541d6ceec5dd283e24e3530aadf59c06449695d19189a7a27bb4c15840d"
   name = "github.com/nats-io/gnatsd"
   packages = [
     "conf",
@@ -829,7 +828,7 @@
   version = "v1.2.0"
 
 [[projects]]
-  digest = "1:665af347df4c5d1ae4c3eacd0754f5337a301f6a3f2444c9993b996605c8c02b"
+  digest = "1:88f1bde4c172e27b05ed46adfbd0e79dc1663a6281e4b39fa3e39d71ead9621d"
   name = "github.com/nats-io/go-nats"
   packages = [
     ".",
@@ -849,7 +848,7 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:7a69f6a3a33929f8b66aa39c93868ad1698f06417fe627ae067559beb94504bd"
+  digest = "1:501cce26a54c785458b0dd54a08ddd984d4ad0c198255430d5d37cd2efe23149"
   name = "github.com/nsqio/go-nsq"
   packages = ["."]
   pruneopts = ""
@@ -865,7 +864,7 @@
   version = "v1.0.0-rc1"
 
 [[projects]]
-  digest = "1:f26c8670b11e29a49c8e45f7ec7f2d5bac62e8fd4e3c0ae1662baa4a697f984a"
+  digest = "1:0d08f7224705b1df80beee92ffbdc63ab13fd6f6eb80bf287735f9bc7e8b83eb"
   name = "github.com/opencontainers/image-spec"
   packages = [
     "specs-go",
@@ -884,7 +883,7 @@
   revision = "a52f2342449246d5bcc273e65cbdcfa5f7d6c63c"
 
 [[projects]]
-  digest = "1:78fb99d6011c2ae6c72f3293a83951311147b12b06a5ffa43abf750c4fab6ac5"
+  digest = "1:bba12aa4747b212f75db3e7fee73fe1b66d303cb3ff0c1984b7f2ad20e8bd2bc"
   name = "github.com/opentracing/opentracing-go"
   packages = [
     ".",
@@ -896,7 +895,7 @@
   version = "v1.0.2"
 
 [[projects]]
-  digest = "1:fea0e67285d900e5a0a7ec19ff4b4c82865a28dddbee8454c5360ad908f7069c"
+  digest = "1:c6c0db6294924072f98a0de090d200bae4b7102b12a443ba9569c4ba7df52aa1"
   name = "github.com/openzipkin/zipkin-go-opentracing"
   packages = [
     ".",
@@ -911,7 +910,7 @@
   version = "v0.3.4"
 
 [[projects]]
-  digest = "1:29e34e58f26655c4d73135cdfc0517ea2ff1483eff34e5d5ef4b6fddbb81e31b"
+  digest = "1:41de12a4684237dd55a11260c941c2c58a055951985e9473ba1661175a13fea7"
   name = "github.com/pierrec/lz4"
   packages = [
     ".",
@@ -949,7 +948,7 @@
   revision = "e517b90714f7c0eabe6d2e570a5886ae077d6db6"
 
 [[projects]]
-  digest = "1:4142d94383572e74b42352273652c62afec5b23f325222ed09198f46009022d1"
+  digest = "1:981835985f655d1d380cc6aa7d9fa9ad7abfaf40c75da200fd40d864cd05a7c3"
   name = "github.com/prometheus/client_golang"
   packages = [
     "prometheus",
@@ -961,7 +960,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:185cf55b1f44a1bf243558901c3f06efa5c64ba62cfdcbb1bf7bbe8c3fb68561"
+  digest = "1:562d53e436b244a9bb5c1ff43bcaf4882e007575d34ec37717b15751c65cc63a"
   name = "github.com/prometheus/client_model"
   packages = ["go"]
   pruneopts = ""
@@ -969,7 +968,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:bfbc121ef802d245ef67421cff206615357d9202337a3d492b8f668906b485a8"
+  digest = "1:6a8420870eb2935977da1fff0f3afca9bdb3f1e66258c9e91a8a7ce0b5417c3b"
   name = "github.com/prometheus/common"
   packages = [
     "expfmt",
@@ -982,7 +981,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:b694a6bdecdace488f507cff872b30f6f490fdaf988abd74d87ea56406b23b6e"
+  digest = "1:00fca823dfcdd8107226f67215afd948b001525223ed955a05b33a4c885c9591"
   name = "github.com/prometheus/procfs"
   packages = [
     ".",
@@ -995,7 +994,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:15bcdc717654ef21128e8af3a63eec39a6d08a830e297f93d65163f87c8eb523"
+  digest = "1:1b65925989a4dfb6d98ef1d530cda33ab1ff25945b14a22a8b8bb27cc282af70"
   name = "github.com/rcrowley/go-metrics"
   packages = ["."]
   pruneopts = ""
@@ -1003,7 +1002,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:7fc2f428767a2521abc63f1a663d981f61610524275d6c0ea645defadd4e916f"
+  digest = "1:d8fe9f454582e04b5693b59cdebe3f0bd9dc29ad9651bfb1633cba4658b66c65"
   name = "github.com/samuel/go-zookeeper"
   packages = ["zk"]
   pruneopts = ""
@@ -1018,7 +1017,7 @@
   version = "v1.2.0"
 
 [[projects]]
-  digest = "1:02715a2fb4b9279af36651a59a51dd4164eb689bd6785874811899f43eeb2a54"
+  digest = "1:69f59b1266c4d59e90f916b90a6d6038c7373277dbb87afa4d82137ffec87f4f"
   name = "github.com/shirou/gopsutil"
   packages = [
     "cpu",
@@ -1043,7 +1042,7 @@
   revision = "bb4de0191aa41b5507caa14b0650cdbddcd9280b"
 
 [[projects]]
-  digest = "1:8cf46b6c18a91068d446e26b67512cf16f1540b45d90b28b9533706a127f0ca6"
+  digest = "1:f2cc92b78b2f3b76ab0f9daddddd28627bcfcc6cacf119029aa3850082d95079"
   name = "github.com/sirupsen/logrus"
   packages = ["."]
   pruneopts = ""
@@ -1052,7 +1051,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:4b0cabe65ca903a7b2a3e6272c5304eb788ce196d35ecb901c6563e5e7582443"
+  digest = "1:79e73b87cb07e380d1a3aaa14fbcc418e0d42eede5f971e7ee2f4a6e6d531deb"
   name = "github.com/soniah/gosnmp"
   packages = ["."]
   pruneopts = ""
@@ -1060,14 +1059,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:4e8f1cae8e6d83af9000d82566efb8823907dae77ba4f1d76ff28fdd197c3c90"
+  digest = "1:0a1f8d01a0191f558910bcbfd7e1dc11a53ac374473d13b68b8fe520f21efb07"
   name = "github.com/streadway/amqp"
   packages = ["."]
   pruneopts = ""
   revision = "e5adc2ada8b8efff032bf61173a233d143e9318e"
 
 [[projects]]
-  digest = "1:711eebe744c0151a9d09af2315f0bb729b2ec7637ef4c410fa90a18ef74b65b6"
+  digest = "1:34062a2274daa6ec4d2f50d6070cc51cf4674d6d553ed76b406cb3425b9528e8"
   name = "github.com/stretchr/objx"
   packages = ["."]
   pruneopts = ""
@@ -1075,7 +1074,7 @@
   version = "v0.1.1"
 
 [[projects]]
-  digest = "1:c587772fb8ad29ad4db67575dad25ba17a51f072ff18a22b4f0257a4d9c24f75"
+  digest = "1:bc2a12c8863e1080226b7bc69192efd6c37aaa9b85cec508b0a8f54fabb9bd9f"
   name = "github.com/stretchr/testify"
   packages = [
     "assert",
@@ -1103,7 +1102,7 @@
   revision = "1731857f09b1f38450e2c12409748407822dc6be"
 
 [[projects]]
-  digest = "1:026b6ceaabbacaa147e94a63579efc3d3c73e00c73b67fa5c43ab46191ed04eb"
+  digest = "1:6c193a7a07f4d270c6dd3f968d8cbea314737dd6819ba4e5626d2b30c2fccab1"
   name = "github.com/vishvananda/netlink"
   packages = ["nl"]
   pruneopts = ""
@@ -1118,7 +1117,7 @@
   revision = "13995c7128ccc8e51e9a6bd2b551020a27180abd"
 
 [[projects]]
-  digest = "1:343f20460c11a0d0529fe532553bfef9446918d1a1fda6d8661eb27d5b1a68b8"
+  digest = "1:23e2b9f3a20cd4a6427147377255ec2f6237e8606fa6ef0707ed79b7bfbe3a83"
   name = "github.com/vjeantet/grok"
   packages = ["."]
   pruneopts = ""
@@ -1126,7 +1125,7 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:f9fe29bf856d49f9a51d6001588cb5ee5d65c8a7ff5e8b0dd5423c3a510f0833"
+  digest = "1:e27a90b038891891bb33cb72cb30b8f1b30307e99fd0caf18d3073ac730d4160"
   name = "github.com/vmware/govmomi"
   packages = [
     ".",
@@ -1157,7 +1156,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:98ed05e9796df287b90c1d96854e3913c8e349dbc546412d3cabb472ecf4b417"
+  digest = "1:5383edd40c7f6c95a7dc46a47bf0c83de4bf40a4252f12fa803f790037addffc"
   name = "github.com/wvanbergen/kafka"
   packages = ["consumergroup"]
   pruneopts = ""
@@ -1165,7 +1164,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:12aff3cc417907bf9f683a6bf1dc78ffb08e41bc69f829491e593ea9b951a3cf"
+  digest = "1:f936b4936e1b092cc41c9b33fdc990ad78386545f1ffeca8427c72b2605bca85"
   name = "github.com/wvanbergen/kazoo-go"
   packages = ["."]
   pruneopts = ""
@@ -1173,7 +1172,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:c5918689b7e187382cc1066bf0260de54ba9d1b323105f46ed2551d2fb4a17c7"
+  digest = "1:9946d558a909f63e31332c77b82649522da97ae7f7cfbfebc6f53549ab6b3e0f"
   name = "github.com/yuin/gopher-lua"
   packages = [
     ".",
@@ -1185,7 +1184,7 @@
   revision = "46796da1b0b4794e1e341883a399f12cc7574b55"
 
 [[projects]]
-  digest = "1:8c8ec859c77fccd10a347b7219b597c4c21c448949e8bdf3fc3e6f4c78f952b4"
+  digest = "1:3ae05b875291576f65ecdcf7bee966cc3cec691153c6dcc780e07af82a631ec8"
   name = "go.opencensus.io"
   packages = [
     ".",
@@ -1209,7 +1208,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:0773b5c3be42874166670a20aa177872edb450cd9fc70b1df97303d977702a50"
+  digest = "1:21100b2e8b6922303dd109da81b3134ed0eff05cb3402881eabde9cce8f4e5e6"
   name = "golang.org/x/crypto"
   packages = [
     "bcrypt",
@@ -1227,7 +1226,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:00ff990baae4665bb0a8174af5ff78228574227ed96c89671247a56852a50e21"
+  digest = "1:58d8f8f3ad415b10d2145316519e5b7995b7cf9e663b33a1e9e0c2ddd96c1d58"
   name = "golang.org/x/net"
   packages = [
     "bpf",
@@ -1255,7 +1254,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "0:"
+  digest = "1:ae181e046572bff397421c415715120190004207493745fec4b385925dc13f6d"
   name = "golang.org/x/oauth2"
   packages = [
     ".",
@@ -1270,7 +1269,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:677e38cad6833ad266ec843739d167755eda1e6f2d8af1c63102b0426ad820db"
+  digest = "1:a8944db88149e7ecbea4b760c625b9ccf455fceae21387bc8890c3589d28b623"
   name = "golang.org/x/sys"
   packages = [
     "unix",
@@ -1285,7 +1284,7 @@
   revision = "ac767d655b305d4e9612f5f6e33120b9176c4ad4"
 
 [[projects]]
-  digest = "1:5acd3512b047305d49e8763eef7ba423901e85d5dd2fd1e71778a0ea8de10bd4"
+  digest = "1:af9bfca4298ef7502c52b1459df274eed401a4f5498b900e9a92d28d3d87ac5a"
   name = "golang.org/x/text"
   packages = [
     "collate",
@@ -1321,7 +1320,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:2d878ecef4b17dbdd067b8fb98eb64f768f0802b1176b91b9e3c01b457efd01f"
+  digest = "1:ba05875c70ff19358de571152ee364d27d80b9b27d1a0d9a4be45508bc68bfcf"
   name = "google.golang.org/api"
   packages = [
     "googleapi/transport",
@@ -1336,7 +1335,7 @@
   revision = "19ff8768a5c0b8e46ea281065664787eefc24121"
 
 [[projects]]
-  digest = "0:"
+  digest = "1:eede11c81b63c8f6fd06ef24ba0a640dc077196ec9b7a58ecde03c82eee2f151"
   name = "google.golang.org/appengine"
   packages = [
     ".",
@@ -1359,7 +1358,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:b1443b4e3cc990c84d27fcdece9d3302158c67dba870e33a6937a2c0076388c2"
+  digest = "1:8d093c040b734e160cbe8291c7b539c36d2c6dd4581c4bb37cff56078c65bd07"
   name = "google.golang.org/genproto"
   packages = [
     "googleapis/api/annotations",
@@ -1375,7 +1374,7 @@
   revision = "fedd2861243fd1a8152376292b921b394c7bef7e"
 
 [[projects]]
-  digest = "1:5f31b45ee9da7a87f140bef3ed0a7ca34ea2a6d38eb888123b8e28170e8aa4f2"
+  digest = "1:05f2028524c4eada11e3f46d23139f23e9e0a40b2552207a5af278e8063ce782"
   name = "google.golang.org/grpc"
   packages = [
     ".",
@@ -1410,7 +1409,7 @@
   version = "v1.13.0"
 
 [[projects]]
-  digest = "1:15d017551627c8bb091bde628215b2861bed128855343fdd570c62d08871f6e1"
+  digest = "1:2840683aa0e9980689f85bf48b2a56ec7a108fd089f12af8ea7d98c172819589"
   name = "gopkg.in/alecthomas/kingpin.v2"
   packages = ["."]
   pruneopts = ""
@@ -1418,7 +1417,7 @@
   version = "v2.2.6"
 
 [[projects]]
-  digest = "1:3cad99e0d1f94b8c162787c12e59d0a0b9df1ef75590eb145cdd625479091efe"
+  digest = "1:a8f8c1725195c4324d4350fae001524ca7489e40d9b6bb47598772e3faa103ba"
   name = "gopkg.in/asn1-ber.v1"
   packages = ["."]
   pruneopts = ""
@@ -1434,7 +1433,7 @@
   version = "v2.0.0"
 
 [[projects]]
-  digest = "1:eb53021a8aa3f599d29c7102e65026242bdedce998a54837dc67f14b6a97c5fd"
+  digest = "1:b2106f1668ea5efc1ecc480f7e922a093adb9563fd9ce58585292871f0d0f229"
   name = "gopkg.in/fsnotify.v1"
   packages = ["."]
   pruneopts = ""
@@ -1443,7 +1442,7 @@
   version = "v1.4.7"
 
 [[projects]]
-  digest = "1:960720207d3d0992995f4576e1366fd9e9b1483473b07fb7243144f75f5b1546"
+  digest = "1:5fa5df18f3bd9cad28ed7f263b15da217945735110898fa2b9af25cdafb9cbf3"
   name = "gopkg.in/gorethink/gorethink.v3"
   packages = [
     ".",
@@ -1456,7 +1455,7 @@
   version = "v3.0.5"
 
 [[projects]]
-  digest = "1:367baf06b7dbd0ef0bbdd785f6a79f929c96b0c18e9d3b29c0eed1ac3f5db133"
+  digest = "1:74163d1887c0821951e6f1795a1d10338f45f09d9067cb4a8edcf7ee481724ee"
   name = "gopkg.in/ldap.v2"
   packages = ["."]
   pruneopts = ""
@@ -1465,7 +1464,7 @@
 
 [[projects]]
   branch = "v2"
-  digest = "1:f54ba71a035aac92ced3e902d2bff3734a15d1891daff73ec0f90ef236750139"
+  digest = "1:f799e95918890212dcf4ce5951291061d318f689977ec9cea0417b08433c2a9d"
   name = "gopkg.in/mgo.v2"
   packages = [
     ".",
@@ -1478,7 +1477,7 @@
   revision = "9856a29383ce1c59f308dd1cf0363a79b5bef6b5"
 
 [[projects]]
-  digest = "1:b49c4d3115800eace659c9a6a5c384a922f5b210178b24a01abb10731f404ea2"
+  digest = "1:427414c304a47b497759094220ce42dd2e838ab7d52de197c633b800c6ff84b5"
   name = "gopkg.in/olivere/elastic.v5"
   packages = [
     ".",
@@ -1544,7 +1543,6 @@
     "github.com/bsm/sarama-cluster",
     "github.com/coreos/go-systemd/activation",
     "github.com/couchbase/go-couchbase",
-    "github.com/dcos/dcos-go/dcos",
     "github.com/dcos/dcos-go/dcos/http/transport",
     "github.com/dcos/dcos-metrics/producers",
     "github.com/dcos/dcos-metrics/producers/http",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -272,8 +272,7 @@
   revision = "0f9f3da35068c4b3cdc15e441f574d7c01beff13"
 
 [[projects]]
-  branch = "1.11.x"
-  digest = "1:d061734870c6f8f5553f6156faea85efc9395ab011ecdb42f554d3b0b83fe4f7"
+  digest = "1:eaf32f37baab0ff8618e50aebf594c210bfe41a26b3a96b9e522910b0a317253"
   name = "github.com/dcos/dcos-metrics"
   packages = [
     "producers",
@@ -281,7 +280,7 @@
     "util/producers",
   ]
   pruneopts = ""
-  revision = "d9a66c43278f20a33342a090252b559fa7022a67"
+  revision = "7d64a97637d3cc5cd34db0a5cc575f13af7129b5"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1543,6 +1543,7 @@
     "github.com/aws/aws-sdk-go/service/cloudwatch",
     "github.com/aws/aws-sdk-go/service/kinesis",
     "github.com/bsm/sarama-cluster",
+    "github.com/coreos/go-systemd/activation",
     "github.com/couchbase/go-couchbase",
     "github.com/dcos/dcos-go/dcos",
     "github.com/dcos/dcos-go/dcos/http/transport",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -252,7 +252,7 @@
 
 [[constraint]]
   name = "github.com/dcos/dcos-metrics"
-  revision = "d9a66c43278f20a33342a090252b559fa7022a67"
+  revision = "7d64a97637d3cc5cd34db0a5cc575f13af7129b5"
 
 [[constraint]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -257,3 +257,7 @@
 [[constraint]]
   branch = "master"
   name = "github.com/dcos/dcos-go"
+
+[[constraint]]
+  name = "github.com/coreos/go-systemd"
+  version = "18.0.0"

--- a/dcosutil/systemd.go
+++ b/dcosutil/systemd.go
@@ -1,0 +1,25 @@
+package dcosutil
+
+import (
+	"net"
+
+	"github.com/coreos/go-systemd/activation"
+)
+
+var cachedListeners map[string][]net.Listener
+
+// ListenersWithNames wraps activation.ListenersWithNames. It caches the return value after the first call, and returns
+// the cached value in subsequent calls. activation.ListenersWithNames will return nil after the first call, so it can't be used by multiple plugins without coordination.
+func ListenersWithNames() (map[string][]net.Listener, error) {
+	if cachedListeners != nil {
+		return cachedListeners, nil
+	}
+
+	listeners, err := activation.ListenersWithNames()
+	if err != nil {
+		return nil, err
+	}
+
+	cachedListeners = listeners
+	return cachedListeners, nil
+}

--- a/plugins/inputs/dcos_statsd/README.md
+++ b/plugins/inputs/dcos_statsd/README.md
@@ -33,6 +33,8 @@ generate it using `telegraf --usage dcos_statsd`.
 [[inputs.dcos_statsd]]
   ## The address on which the command API should listen
   listen = "localhost:8888"
+  ## The name of the systemd socket on which the command API should listen. Leave unset to listen on an address.
+  #systemd_socket_name = "dcos-statsd.socket"
   ## The directory in which container information is persisted
   containers_dir = "/run/dcos/mesos/isolators/com_mesosphere_MetricsIsolatorModule/containers"
   ## The period after which requests to the API should time out

--- a/plugins/outputs/dcos_metrics/README.md
+++ b/plugins/outputs/dcos_metrics/README.md
@@ -10,6 +10,9 @@ The DC/OS Metrics output provides a [DC/OS Metrics API](https://docs.mesosphere.
   # Address to listen on. Leave unset to listen on a systemd-provided socket.
   listen = ":8080"
 
+  # Systemd socket name to listen on. Leave unset to listen on a port.
+  #systemd_socket_name = "dcos-metrics.socket"
+
   # Duration to cache metrics in memory.
   cache_expiry = "2m"
 


### PR DESCRIPTION
This adds a `systemd_socket_name` config parameter to the `dcos_statsd` and `dcos_metrics` plugins. This config parameter can be used to specify the name of a systemd socket for these plugins to listen on.

This config parameter requires systemd 227, which adds the `sd_listen_fds_with_names()` API that it depends on. https://lwn.net/Articles/660733/

https://jira.mesosphere.com/browse/DCOS_OSS-4465

DC/OS PR: https://github.com/dcos/dcos/pull/4611