### PR TITLE
Initial nginx_vts_processor

### DIFF
--- a/plugins/processors/all/all.go
+++ b/plugins/processors/all/all.go
@@ -5,6 +5,7 @@ import (
 	_ "github.com/influxdata/telegraf/plugins/processors/dcos_metadata"
 	_ "github.com/influxdata/telegraf/plugins/processors/enum"
 	_ "github.com/influxdata/telegraf/plugins/processors/lowercase"
+	_ "github.com/influxdata/telegraf/plugins/processors/nginx_vts_filter"
 	_ "github.com/influxdata/telegraf/plugins/processors/override"
 	_ "github.com/influxdata/telegraf/plugins/processors/parser"
 	_ "github.com/influxdata/telegraf/plugins/processors/printer"

--- a/plugins/processors/nginx_vts_filter/README.md
+++ b/plugins/processors/nginx_vts_filter/README.md
@@ -1,0 +1,42 @@
+# Nginx VTS Filter Processor Plugin
+
+The `nginx_vts_filter` processor converts specific measurements, tags.
+
+### Configuration:
+
+```toml
+[[processors.nginx_vts_filter]]
+
+  [[processors.nginx_vts_filter.convert]]
+    measurement = "nginx_vts_filter_requests_total"
+    tags_delimiter = ","
+    key_value_delimiter = "="
+
+  [[processors.nginx_vts_filter.convert]]
+    measurement = "nginx_vts_filter_bytes_total"
+    tags_delimiter = ","
+    key_value_delimiter = "="
+
+  [[processors.nginx_vts_filter.convert]]
+    measurement = "nginx_vts_filter_request_seconds"
+    tags_delimiter = ","
+    key_value_delimiter = "="
+
+```
+
+### Tags:
+
+The `filter` and `filter_name` tags which contain key-value pairs like `upstream=Bouncer,status=200` are unmarshalled by this processor, so that they replace the initial tags.
+
+Measurement names are also altered in a particular fashion explained below.
+
+`*_x_y_*{filter="a=*,b=*", filter_name="c=*,d=*"}` becomes `*_a_c_*{a=*,b=*,c=*,d=*}`
+
+The delimter between nginx_vts_filter tags is ',' by default. The key value pairs of each tag are separated by the '=' delimiter by default.
+
+### Example processing:
+
+```diff
+- nginx_vts_filter_requests_total{filter="upstream=Bouncer,backend=,status=401",filter_name="client=Mesos/1.8.0 authorizer (master)"}
++ nginx_upstream_client_requests_total{upstream="Bouncer",backend="",status="401",client="Mesos/1.8.0 authorizer (master)"}
+```

--- a/plugins/processors/nginx_vts_filter/nginx_vts_filter.go
+++ b/plugins/processors/nginx_vts_filter/nginx_vts_filter.go
@@ -1,0 +1,196 @@
+package nginx_vts_filter
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/processors"
+	"github.com/pkg/errors"
+)
+
+const sampleConfig = `
+[[processors.nginx_vts_filter]]
+
+  [[processors.nginx_vts_filter.convert]]
+    measurement = "nginx_vts_filter_requests_total"
+    tags_delimiter = ","
+    key_value_delimiter = "="
+
+  [[processors.nginx_vts_filter.convert]]
+    measurement = "nginx_vts_filter_bytes_total"
+    tags_delimiter = ","
+    key_value_delimiter = "="
+
+  [[processors.nginx_vts_filter.convert]]
+    measurement = "nginx_vts_filter_request_seconds"
+    tags_delimiter = ","
+    key_value_delimiter = "="
+`
+
+type Convert struct {
+	Measurement       string `toml:"measurement"`
+	TagDelimiter      string `toml:"tag_delimiter"`
+	KeyValueDelimiter string `toml:"key_value_delimiter"`
+}
+
+type NginxVTSFilter struct {
+	Conversions []Convert `toml:"convert"`
+}
+
+func (n *NginxVTSFilter) SampleConfig() string {
+	return sampleConfig
+}
+
+func (n *NginxVTSFilter) Description() string {
+	return "NginxVTSFilter measurements that pass through this filter."
+}
+
+func (n *NginxVTSFilter) Apply(in ...telegraf.Metric) []telegraf.Metric {
+	for _, point := range in {
+		for _, convert := range n.Conversions {
+			// Step 0: Match metric by convert.Measurement config setting
+			name := point.Name()
+			if convert.Measurement == "" || name != convert.Measurement {
+				continue
+			}
+			kvDelimiter := "="
+			if convert.KeyValueDelimiter != "" {
+				kvDelimiter = convert.KeyValueDelimiter
+			}
+			tagDelimiter := ","
+			if convert.TagDelimiter != "" {
+				tagDelimiter = convert.TagDelimiter
+			}
+			//
+			// Step 1: Convert filter tag value into individual tags.
+			// ------------------------------------------------------------
+			// nginx_vts_filter_requests_total{
+			//     filter = ",upstream=Bouncer,backend=,status=401,",
+			//     filter_name = "client=Mesos/1.8.0 authorizer (master)",
+			// }
+			// ------------------------------------------------------------
+			// nginx_vts_filter_requests_total{
+			//     upstream = "Bouncer",
+			//     backend = "",
+			//     status = "401",
+			//     filter_name = "client=Mesos/1.8.0 authorizer (master)",
+			// }
+			filter, ok := point.GetTag("filter")
+			if !ok {
+				log.Printf("E! [processors.nginx_vts_filter] %s has no tag filter", name)
+				continue
+			}
+			filterTags, err := unwrapTags(filter, kvDelimiter, tagDelimiter)
+			if err != nil {
+				log.Printf("E! [processors.nginx_vts_filter] could not unwrap filter tags %s: %v", filter, err)
+				continue
+			}
+			for _, t := range filterTags {
+				point.AddTag(t.Key, t.Value)
+			}
+			point.RemoveTag("filter")
+			//
+			// Step 2: Convert filter_name tag value into new tag.
+			// ------------------------------------------------------------
+			// nginx_vts_filter_requests_total{
+			//     upstream = "Bouncer",
+			//     backend = "",
+			//     status = "401",
+			//     filter_name = "client=Mesos/1.8.0 authorizer (master)",
+			// }
+			// ------------------------------------------------------------
+			// nginx_vts_filter_requests_total{
+			//     upstream = "Bouncer",
+			//     backend = "",
+			//     status = "401",
+			//     client = "Mesos/1.8.0 authorizer (master)",
+			// }
+			filterName, ok := point.GetTag("filter_name")
+			if !ok {
+				log.Printf("E! [processors.nginx_vts_filter] %s has no tag filter_name", name)
+				continue
+			}
+			filterNameTags, err := unwrapTags(filterName, kvDelimiter, tagDelimiter)
+			if err != nil {
+				log.Printf("E! [processors.nginx_vts_filter] could not unwrap filter_name tags %s: %v", filterName, err)
+				continue
+			}
+			for _, t := range filterNameTags {
+				point.AddTag(t.Key, t.Value)
+			}
+			point.RemoveTag("filter_name")
+			//
+			// Step 3: Convert metric name via filter/filter_name tag keys.
+			// ------------------------------------------------------------
+			// nginx_vts_filter_requests_total{
+			//     upstream = "Bouncer",
+			//     backend = "",
+			//     status = "401",
+			//     client = "Mesos/1.8.0 authorizer (master)",
+			// }
+			// ------------------------------------------------------------
+			// nginx_upstream_client_requests_total{
+			//     upstream = "Bouncer",
+			//     backend = "",
+			//     status = "401",
+			//     client = "Mesos/1.8.0 authorizer (master)",
+			// }
+			newName, err := vtsFilterName(name, filterTags, filterNameTags)
+			if err != nil {
+				log.Printf("E! [processors.nginx_vts_filter] could not rename %s: %v", name, err)
+				continue
+			}
+			point.SetName(newName)
+		}
+	}
+	return in
+}
+
+func init() {
+	processors.Add("nginx_vts_filter", func() telegraf.Processor {
+		return &NginxVTSFilter{}
+	})
+}
+
+func kvStringToTag(kv, delimiter string) (telegraf.Tag, error) {
+	tuple := strings.Split(kv, delimiter)
+	if len(tuple) != 2 {
+		return telegraf.Tag{}, fmt.Errorf("not a key-value pair: %s", kv)
+	}
+	return telegraf.Tag{
+		Key:   tuple[0],
+		Value: tuple[1],
+	}, nil
+}
+
+func unwrapTags(kvPairs, kvDelimiter, tagDelimiter string) ([]telegraf.Tag, error) {
+	// Valid filter value format: "a=x,b=y,c=z"
+	kvs := strings.Split(kvPairs, tagDelimiter)
+	tags := make([]telegraf.Tag, 0)
+	for _, s := range kvs {
+		t, err := kvStringToTag(s, kvDelimiter)
+		if err != nil {
+			return nil, errors.Wrap(err, "could not make tag")
+		}
+		tags = append(tags, t)
+	}
+	return tags, nil
+}
+
+func vtsFilterName(name string, filterTags, filterNameTags []telegraf.Tag) (string, error) {
+	if len(filterTags) < 1 {
+		return "", fmt.Errorf("unwrapped tag from filter required")
+	}
+	if len(filterNameTags) < 1 {
+		return "", fmt.Errorf("unwrapped tag from filter_name required")
+	}
+	s := strings.Split(name, "_")
+	if len(s) < 3 {
+		return "", fmt.Errorf("require at least 3 syllabus measurement")
+	}
+	s[1] = filterTags[0].Key
+	s[2] = filterNameTags[0].Key
+	return strings.Join(s, "_"), nil
+}

--- a/plugins/processors/nginx_vts_filter/nginx_vts_filter_test.go
+++ b/plugins/processors/nginx_vts_filter/nginx_vts_filter_test.go
@@ -1,0 +1,175 @@
+package nginx_vts_filter
+
+import (
+	"testing"
+	"time"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/metric"
+	"github.com/stretchr/testify/assert"
+)
+
+func newMetric(name string, tags map[string]string) telegraf.Metric {
+	if tags == nil {
+		tags = map[string]string{}
+	}
+	fields := map[string]interface{}{}
+	m, _ := metric.New(name, tags, fields, time.Now())
+	return m
+}
+
+func TestVTSFilterConvertSuccess(t *testing.T) {
+	n := NginxVTSFilter{
+		Conversions: []Convert{
+			{Measurement: "nginx_vts_filter_requests_total"},
+		},
+	}
+	m := newMetric("nginx_vts_filter_requests_total", map[string]string{"filter": "upstream=Bouncer", "filter_name": "uri=/acs/api/v1/auth/login"})
+	r := n.Apply(m)
+	upstream, ok := r[0].GetTag("upstream")
+	assert.True(t, ok)
+	assert.Equal(t, upstream, "Bouncer")
+	assert.False(t, r[0].HasTag("filter"))
+	uri, ok := r[0].GetTag("uri")
+	assert.True(t, ok)
+	assert.Equal(t, uri, "/acs/api/v1/auth/login")
+	assert.False(t, r[0].HasTag("filter_name"))
+	assert.Equal(t, r[0].Name(), "nginx_upstream_uri_requests_total")
+}
+
+func TestVTSFilterConvertMultipleSuccess(t *testing.T) {
+	n := NginxVTSFilter{
+		Conversions: []Convert{
+			{Measurement: "nginx_vts_filter_requests_total"},
+		},
+	}
+	m := newMetric("nginx_vts_filter_requests_total", map[string]string{"filter": "upstream=Bouncer,backend=,status=401", "filter_name": "uri=/acs/api/v1/auth/login"})
+	r := n.Apply(m)
+	upstream, ok := r[0].GetTag("upstream")
+	assert.True(t, ok)
+	assert.Equal(t, upstream, "Bouncer")
+	backend, ok := r[0].GetTag("backend")
+	assert.True(t, ok)
+	assert.Equal(t, backend, "")
+	status, ok := r[0].GetTag("status")
+	assert.True(t, ok)
+	assert.Equal(t, status, "401")
+	assert.False(t, r[0].HasTag("filter"))
+	uri, ok := m.GetTag("uri")
+	assert.True(t, ok)
+	assert.Equal(t, uri, "/acs/api/v1/auth/login")
+	assert.False(t, r[0].HasTag("filter_name"))
+	assert.Equal(t, r[0].Name(), "nginx_upstream_uri_requests_total")
+}
+
+func TestVTSFilterConvertMultipleSuccessCustomDelimiter(t *testing.T) {
+	n := NginxVTSFilter{
+		Conversions: []Convert{
+			{
+				Measurement:       "nginx_vts_filter_requests_total",
+				KeyValueDelimiter: ":=",
+				TagDelimiter:      "::",
+			},
+		},
+	}
+	m := newMetric("nginx_vts_filter_requests_total", map[string]string{"filter": "upstream:=Bouncer::backend:=::status:=401", "filter_name": "uri:=/acs/api/v1/auth/login"})
+	r := n.Apply(m)
+	upstream, ok := r[0].GetTag("upstream")
+	assert.True(t, ok)
+	assert.Equal(t, upstream, "Bouncer")
+	backend, ok := r[0].GetTag("backend")
+	assert.True(t, ok)
+	assert.Equal(t, backend, "")
+	status, ok := r[0].GetTag("status")
+	assert.True(t, ok)
+	assert.Equal(t, status, "401")
+	assert.False(t, r[0].HasTag("filter"))
+	uri, ok := m.GetTag("uri")
+	assert.True(t, ok)
+	assert.Equal(t, uri, "/acs/api/v1/auth/login")
+	assert.False(t, r[0].HasTag("filter_name"))
+	assert.Equal(t, r[0].Name(), "nginx_upstream_uri_requests_total")
+}
+
+func TestVTSFilterMissing(t *testing.T) {
+	n := NginxVTSFilter{
+		Conversions: []Convert{
+			{Measurement: "nginx_vts_filter_requests_total"},
+		},
+	}
+	m := newMetric("nginx_vts_filter_requests_total", map[string]string{"filter_name": "uri=/acs/api/v1/auth/login"})
+	r := n.Apply(m)
+	assert.True(t, r[0].HasTag("filter_name"))
+	assert.Equal(t, r[0].Name(), "nginx_vts_filter_requests_total")
+}
+
+func TestVTSFilterNameMissing(t *testing.T) {
+	n := NginxVTSFilter{
+		Conversions: []Convert{
+			{Measurement: "nginx_vts_filter_requests_total"},
+		},
+	}
+	m := newMetric("nginx_vts_filter_requests_total", map[string]string{"filter": "upstream=Bouncer"})
+	r := n.Apply(m)
+	upstream, ok := r[0].GetTag("upstream")
+	assert.True(t, ok)
+	assert.Equal(t, upstream, "Bouncer")
+	assert.False(t, r[0].HasTag("filter"))
+	assert.Equal(t, r[0].Name(), "nginx_vts_filter_requests_total")
+}
+
+func TestVTSFilterInvalidKeyValuePair(t *testing.T) {
+	n := NginxVTSFilter{
+		Conversions: []Convert{
+			{Measurement: "nginx_vts_filter_requests_total"},
+		},
+	}
+	m := newMetric("nginx_vts_filter_requests_total", map[string]string{"filter": "upstream=Bouncer,status"})
+	r := n.Apply(m)
+	assert.True(t, r[0].HasTag("filter"))
+	assert.Equal(t, r[0].Name(), "nginx_vts_filter_requests_total")
+}
+
+func TestVTSFilterEmpty(t *testing.T) {
+	n := NginxVTSFilter{
+		Conversions: []Convert{
+			{Measurement: "nginx_vts_filter_requests_total"},
+		},
+	}
+	m := newMetric("nginx_vts_filter_requests_total", map[string]string{"filter": ""})
+	r := n.Apply(m)
+	assert.True(t, r[0].HasTag("filter"))
+	assert.Equal(t, r[0].Name(), "nginx_vts_filter_requests_total")
+}
+
+func TestVTSFilterNameInvalidKeyValuePair(t *testing.T) {
+	n := NginxVTSFilter{
+		Conversions: []Convert{
+			{Measurement: "nginx_vts_filter_requests_total"},
+		},
+	}
+	m := newMetric("nginx_vts_filter_requests_total", map[string]string{"filter": "upstream=Bouncer", "filter_name": "client"})
+	r := n.Apply(m)
+	upstream, ok := r[0].GetTag("upstream")
+	assert.True(t, ok)
+	assert.Equal(t, upstream, "Bouncer")
+	assert.False(t, r[0].HasTag("filter"))
+	assert.True(t, r[0].HasTag("filter_name"))
+	assert.Equal(t, r[0].Name(), "nginx_vts_filter_requests_total")
+}
+
+func TestVTSFilterNameEmpty(t *testing.T) {
+	n := NginxVTSFilter{
+		Conversions: []Convert{
+			{Measurement: "nginx_vts_filter_requests_total"},
+		},
+	}
+	m := newMetric("nginx_vts_filter_requests_total", map[string]string{"filter": "upstream=Bouncer", "filter_name": ""})
+	r := n.Apply(m)
+	upstream, ok := r[0].GetTag("upstream")
+	assert.True(t, ok)
+	assert.Equal(t, upstream, "Bouncer")
+	assert.False(t, r[0].HasTag("filter"))
+	assert.True(t, r[0].HasTag("filter_name"))
+	assert.Equal(t, r[0].Name(), "nginx_vts_filter_requests_total")
+}


### PR DESCRIPTION
This PR adds a processor plugin for transforming metrics gotten from the Nginx VTS module of Admin Router. More specifically it converts `nginx_vts_filter` metrics for fine-grained HTTP stats.

### Required for all PRs:

- [x] Associated README.md updated.
- [x] Has appropriate unit tests.

DC/OS PR: https://github.com/dcos/dcos/pull/4711