### PR TITLE
Prefix prometheus metric names with _ instead of digit

### DIFF
--- a/plugins/outputs/prometheus_client/prometheus_client.go
+++ b/plugins/outputs/prometheus_client/prometheus_client.go
@@ -288,6 +288,12 @@ func (p *PrometheusClient) Collect(ch chan<- prometheus.Metric) {
 }
 
 func sanitize(value string) string {
+	// numeric chars are legal, except at the start of a metric name
+	// if the metric name starts with a number, prefix with underscore
+	c := value[0]
+	if c >= '0' && c <= '9' {
+		value = "_" + value
+	}
 	return invalidNameCharRE.ReplaceAllString(value, "_")
 }
 


### PR DESCRIPTION
This PR prefixes any prometheus metric which starts with a number with an underscore. 

So, `123.foo.bar` becomes `_123_foo_bar` instead of `123_foo_bar`

This prevents Prometheus dropping such metrics. 