### PR TITLE
[1.7.2] Set http client timeout, remove mesos timeout query param

### DIFF
--- a/plugins/inputs/mesos/mesos.go
+++ b/plugins/inputs/mesos/mesos.go
@@ -9,7 +9,6 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -211,8 +210,6 @@ func (m *Mesos) initialize() error {
 		m.Timeout = 100
 	}
 
-	rawQuery := "timeout=" + strconv.Itoa(m.Timeout) + "ms"
-
 	m.masterURLs = make([]*url.URL, 0, len(m.Masters))
 	for _, master := range m.Masters {
 		u, err := parseURL(master, MASTER)
@@ -220,7 +217,6 @@ func (m *Mesos) initialize() error {
 			return err
 		}
 
-		u.RawQuery = rawQuery
 		m.masterURLs = append(m.masterURLs, u)
 	}
 
@@ -231,7 +227,6 @@ func (m *Mesos) initialize() error {
 			return err
 		}
 
-		u.RawQuery = rawQuery
 		m.slaveURLs = append(m.slaveURLs, u)
 	}
 
@@ -309,7 +304,7 @@ func (m *Mesos) createHttpClient() (*http.Client, error) {
 				TLSClientConfig: tlsCfg,
 			},
 			m.UserAgent),
-		Timeout: 4 * time.Second,
+		Timeout: time.Duration(m.Timeout) * time.Millisecond,
 	}
 
 	if m.CACertificatePath != "" {


### PR DESCRIPTION
Backport of https://github.com/dcos/telegraf/pull/50

https://jira.mesosphere.com/browse/DCOS-50672
The HTTP client in the Mesos input plugin was setting its own 4s timeout, which meant the configured timeout value was getting ignored if it were larger than 4s (in DC/OS, we set it to 30s). We should instead use the configured timeout value for the HTTP client timeout. We should also stop sending the timeout query param with the Mesos snapshot request; Mesos timeouts result in partial metrics getting emitted instead of erroring out, which could obfuscate the presence of issues causing the slowness in completing the request.