### PR TITLE
Use mesos agent URL, not localhost, to collect prom metrics

### DIFF
--- a/plugins/inputs/prometheus/prometheus.go
+++ b/plugins/inputs/prometheus/prometheus.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -375,6 +376,24 @@ func (p *Prometheus) Stop() {
 		p.cancel()
 	}
 	p.wg.Wait()
+}
+
+// getMesosHostname extracts the node's hostname from the mesos agent url
+func getMesosHostname(mesosAgentUrl string) (string, error) {
+	u, err := url.Parse(mesosAgentUrl)
+	if err != nil {
+		return "", err
+	}
+	hostname := u.Host
+
+	// SplitHostPort will error if passed an input with no port
+	if strings.ContainsRune(hostname, ':') {
+		hostname, _, err = net.SplitHostPort(hostname)
+	}
+	if hostname == "" {
+		return hostname, fmt.Errorf("could not extract hostname from: %s", mesosAgentUrl)
+	}
+	return hostname, err
 }
 
 // getMesosClient returns an httpcli client configured with the available levels of

--- a/plugins/inputs/prometheus/prometheus_test.go
+++ b/plugins/inputs/prometheus/prometheus_test.go
@@ -106,8 +106,9 @@ func TestPrometheusGeneratesMetricsAlthoughFirstDNSFails(t *testing.T) {
 }
 
 func TestPrometheusGathersMesosMetrics(t *testing.T) {
-	metricsUrl, _ := url.Parse("http://localhost:12345/metrics")
-	federateUrl, _ := url.Parse("http://localhost:12345/federate")
+	// The mock mesos server listens on 127.0.0.1
+	metricsUrl, _ := url.Parse("http://127.0.0.1:12345/metrics")
+	federateUrl, _ := url.Parse("http://127.0.0.1:12345/federate")
 	testCases := map[string]map[string]URLAndAddress{
 		"empty": {},
 		"portlabel": {

--- a/plugins/inputs/prometheus/prometheus_test.go
+++ b/plugins/inputs/prometheus/prometheus_test.go
@@ -139,6 +139,8 @@ func TestPrometheusGathersMesosMetrics(t *testing.T) {
 			p := &Prometheus{
 				MesosTimeout:  internal.Duration{Duration: 100 * time.Millisecond},
 				MesosAgentUrl: server.URL,
+				// mesosHostname is assigned in Start()
+				mesosHostname: "127.0.0.1",
 			}
 
 			urls, err := p.GetAllURLs()

--- a/plugins/inputs/prometheus/prometheus_test.go
+++ b/plugins/inputs/prometheus/prometheus_test.go
@@ -148,3 +148,27 @@ func TestPrometheusGathersMesosMetrics(t *testing.T) {
 		})
 	}
 }
+
+func TestGetMesosHostname(t *testing.T) {
+	goodUrls := map[string]string{
+		"http://localhost":                       "localhost",
+		"http://localhost:9090":                  "localhost",
+		"http://192.168.2.2":                     "192.168.2.2",
+		"http://192.168.2.2:9090":                "192.168.2.2",
+		"https://192.168.2.2":                    "192.168.2.2",
+		"http://some-agent.testing.example.com/": "some-agent.testing.example.com",
+	}
+	badUrls := []string{
+		"$UNPARSED_ENVIRONMENT_VARIABLE",
+		"",
+	}
+	for input, expected := range goodUrls {
+		output, err := getMesosHostname(input)
+		assert.Nil(t, err)
+		assert.Equal(t, expected, output)
+	}
+	for _, input := range badUrls {
+		_, err := getMesosHostname(input)
+		assert.NotNil(t, err)
+	}
+}


### PR DESCRIPTION
We naively assumed that mesos tasks' prometheus endpoints were bound to the
host's localhost. This may not be the case. We now assume that they are bound
to the mesos agent's hostname instead.

