### PR TITLE
Increase timeout for dcos_metadata test

### DIFF
--- a/plugins/processors/dcos_metadata/dcos_metadata_test.go
+++ b/plugins/processors/dcos_metadata/dcos_metadata_test.go
@@ -338,7 +338,7 @@ func TestApply(t *testing.T) {
 				assert.Equal(t, expected.Tags(), actual.Tags())
 			}
 
-			waitForContainersToEqual(t, &dm, tc.containers, 100*time.Millisecond)
+			waitForContainersToEqual(t, &dm, tc.containers, 2*time.Second)
 		})
 	}
 }


### PR DESCRIPTION
This increases the timeout for TestApply in order to make it less flaky.

https://jira.mesosphere.com/browse/DCOS_OSS-5005