### PR TITLE
Add framework_id tag to framework_offers metrics

### DIFF
--- a/plugins/inputs/mesos/mesos.go
+++ b/plugins/inputs/mesos/mesos.go
@@ -47,6 +47,7 @@ type Mesos struct {
 // combination of tags
 type TaggedField struct {
 	FrameworkName string
+	FrameworkId   string
 	CallType      string
 	EventType     string
 	OperationType string
@@ -62,6 +63,9 @@ func (tf TaggedField) hash() string {
 
 	if tf.FrameworkName != "" {
 		buffer += "_fn:" + tf.FrameworkName
+	}
+	if tf.FrameworkId != "" {
+		buffer += "_fi:" + tf.FrameworkId
 	}
 	if tf.CallType != "" {
 		buffer += "_ct:" + tf.CallType
@@ -92,6 +96,9 @@ func (tf TaggedField) tags() fieldTags {
 
 	if tf.FrameworkName != "" {
 		tags["framework_name"] = tf.FrameworkName
+	}
+	if tf.FrameworkId != "" {
+		tags["framework_id"] = tf.FrameworkId
 	}
 	if tf.CallType != "" {
 		tags["call_type"] = tf.CallType
@@ -888,6 +895,7 @@ func generateTaggedField(parts []string) TaggedField {
 	if parts[0] == "master" {
 		// Mesos encodes framework names in metrics responses.
 		tf.FrameworkName = decodeFrameworkName(parts[2])
+		tf.FrameworkId = parts[3]
 		if len(parts) == 5 {
 			// e.g. /master/frameworks/calls_total
 			tf.FieldName = fmt.Sprintf("%s/%s/%s_total", parts[0], parts[1], parts[4])

--- a/plugins/inputs/mesos/mesos_test.go
+++ b/plugins/inputs/mesos/mesos_test.go
@@ -521,6 +521,7 @@ func TestMesosMaster(t *testing.T) {
 			"role":           "master",
 			"state":          "leader",
 			"framework_name": "framework name",
+			"framework_id":   "abc-123",
 		},
 		{
 			"server":         m.masterURLs[0].Hostname(),
@@ -528,6 +529,7 @@ func TestMesosMaster(t *testing.T) {
 			"role":           "master",
 			"state":          "leader",
 			"framework_name": "framework name",
+			"framework_id":   "abc-123",
 			"task_state":     "task_killing",
 		},
 		{
@@ -536,6 +538,7 @@ func TestMesosMaster(t *testing.T) {
 			"role":           "master",
 			"state":          "leader",
 			"framework_name": "framework name",
+			"framework_id":   "abc-123",
 			"task_state":     "task_dropped",
 		},
 		{
@@ -544,6 +547,7 @@ func TestMesosMaster(t *testing.T) {
 			"role":           "master",
 			"state":          "leader",
 			"framework_name": "framework name",
+			"framework_id":   "abc-123",
 			"role_name":      "*",
 		},
 		{
@@ -552,6 +556,7 @@ func TestMesosMaster(t *testing.T) {
 			"role":           "master",
 			"state":          "leader",
 			"framework_name": "framework name",
+			"framework_id":   "abc-123",
 			"call_type":      "accept",
 		},
 		{
@@ -560,6 +565,7 @@ func TestMesosMaster(t *testing.T) {
 			"role":           "master",
 			"state":          "leader",
 			"framework_name": "framework name",
+			"framework_id":   "abc-123",
 			"event_type":     "error",
 		},
 		{
@@ -568,6 +574,7 @@ func TestMesosMaster(t *testing.T) {
 			"role":           "master",
 			"state":          "leader",
 			"framework_name": "framework name",
+			"framework_id":   "abc-123",
 			"operation_type": "create",
 		},
 		// allocator


### PR DESCRIPTION
This adds a `framework_id` tag to Mesos master `framework_offers` metrics, so that metrics from different framework instances with the same name can be distinguished. These metrics are documented here: https://mesos.apache.org/documentation/latest/monitoring/#frameworks.

https://jira.mesosphere.com/browse/DCOS-53302

DC/OS PR: https://github.com/dcos/dcos/pull/6049