### PR TITLE
Expose AllowedPendingMessages in dcos_statsd

### DIFF
--- a/plugins/inputs/dcos_statsd/README.md
+++ b/plugins/inputs/dcos_statsd/README.md
@@ -44,6 +44,8 @@ generate it using `telegraf --usage dcos_statsd`.
   timeout = "15s"
   ## The hostname or IP address on which to host statsd servers
   statsd_host = "198.51.100.1"
+  ## The number of pending messages each statsd server can hold (default 10000)
+  #allowed_pending_messages = 10000
 ```
 
 With minimal configuration, this plugin expects the cluster to be in permissive mode. Strict mode requires TLS 

--- a/plugins/inputs/dcos_statsd/dcos_statsd_test.go
+++ b/plugins/inputs/dcos_statsd/dcos_statsd_test.go
@@ -107,7 +107,7 @@ func TestGather(t *testing.T) {
 		assert.Fail(t, fmt.Sprintf("Could not create temp dir: %s", err))
 	}
 	defer os.RemoveAll(dir)
-	ds := DCOSStatsd{StatsdHost: "127.0.0.1", ContainersDir: dir}
+	ds := DCOSStatsd{StatsdHost: "127.0.0.1", ContainersDir: dir, AllowedPendingMessages: 321}
 
 	addr := startTestServer(t, &ds)
 	defer ds.Stop()
@@ -122,6 +122,11 @@ func TestGather(t *testing.T) {
 	assert.Equal(t, "abc123", abc.Id)
 	assert.NotEmpty(t, abc.StatsdHost)
 	assert.NotEmpty(t, abc.StatsdPort)
+	// the container json object does not serialize its internals, hence we
+	// retrieve it directly from the DCOSStatsd object
+	ctr := ds.containers["abc123"]
+	assert.NotNil(t, ctr)
+	assert.Equal(t, 321, ctr.Server.AllowedPendingMessages)
 
 	t.Log("A container on a known port")
 	xyzport := findFreePort()


### PR DESCRIPTION
This PR exposes the `AllowedPendingMessages` configuration option in the dcos_statsd configuration. It was previously hardcoded to 10,000.

To test:
1. Compile the telegraf binary with `make telegraf` (you may need to set `GOOS=linux` if you are working on OSX or windows)
1. SCP the telegraf binary up to an agent in a DC/OS cluster.
1. SSH to the same agent.
1. Replace the existing telegraf binary (`/opt/mesosphere/packages/telegraf--<some-hash>/bin/telegraf`) with the new telegraf binary (ensure it's executable)
1. Modify the telegraf agent configuration file (`/opt/mesosphere/etc/telegraf/telegraf.d/agent.conf`) with the newly added parameter (you'll need to add it to the `dcos_statsd` block) 
1. `sudo systemctl restart dcos-telegraf`
1. Check to make sure no errors are showing via `journalctl -u dcos-telegraf -f`
1. Start up a known noisy workload on the same agent to check that tuning the parameter fixes the issue. 